### PR TITLE
Fix deserialization of pooling layer

### DIFF
--- a/src/ConvNetSharp.Tests/SerializationTests.cs
+++ b/src/ConvNetSharp.Tests/SerializationTests.cs
@@ -16,6 +16,8 @@ namespace ConvNetSharp.Tests
             net.AddLayer(new InputLayer(5, 5, 3));
             var conv = new ConvLayer(2, 2, 16);
             net.AddLayer(conv);
+            var pool = new PoolLayer(2, 2);
+            net.AddLayer(pool);
             var fullycon = new FullyConnLayer(3);
             net.AddLayer(fullycon);
             net.AddLayer(new SoftmaxLayer(3));
@@ -44,7 +46,16 @@ namespace ConvNetSharp.Tests
                 }
             }
 
-            var deserializedFullyCon = net.Layers[2] as FullyConnLayer;
+            var deserializedPool = net.Layers[2] as PoolLayer;
+            Assert.NotNull(deserializedPool);
+            Assert.AreEqual(2, deserializedPool.Height);
+            Assert.AreEqual(2, deserializedPool.Width);
+            Assert.AreEqual(2, deserializedPool.OutputHeight);
+            Assert.AreEqual(2, deserializedPool.OutputWidth);
+            Assert.AreEqual(0, deserializedPool.Pad);
+            Assert.AreEqual(2, deserializedPool.Stride);
+
+            var deserializedFullyCon = net.Layers[3] as FullyConnLayer;
             Assert.NotNull(deserializedFullyCon);
             Assert.NotNull(deserializedFullyCon.Filters);
             Assert.AreEqual(3, deserializedFullyCon.Filters.Count);
@@ -57,8 +68,8 @@ namespace ConvNetSharp.Tests
                 }
             }
 
-            Assert.IsTrue(net.Layers[3] is SoftmaxLayer);
-            Assert.AreEqual(3, ((SoftmaxLayer)net.Layers[3]).ClassCount);
+            Assert.IsTrue(net.Layers[4] is SoftmaxLayer);
+            Assert.AreEqual(3, ((SoftmaxLayer)net.Layers[4]).ClassCount);
         }
 
         [Test]

--- a/src/ConvNetSharp/Layers/PoolLayer.cs
+++ b/src/ConvNetSharp/Layers/PoolLayer.cs
@@ -23,13 +23,13 @@ namespace ConvNetSharp.Layers
             this.Height = height;
         }
 
-        [DataMember]
+        [DataMember(Order = 0)]
         public int Width { get; private set; }
 
-        [DataMember]
+        [DataMember(Order = 0)]
         public int Height { get; private set; }
 
-        [DataMember]
+        [DataMember(Order = 1)]
         public int Stride
         {
             get
@@ -43,7 +43,7 @@ namespace ConvNetSharp.Layers
             }
         }
 
-        [DataMember]
+        [DataMember(Order = 1)]
         public int Pad
         {
             get


### PR DESCRIPTION
Pooling layer output height and width were not deserialized correctly because the UpdateOutputSize method runs when the "pad" and "stride" variables are set and this happens before the height and width variables are set, resulting in incorrect answers. This is because json variables are serialized alphabetically. Simply setting the order in which the properties should be serialized fixes this problem.
Also expanded the serialization test to test for this case