### PR TITLE
Training error after reading saved json file

### DIFF
--- a/src/ConvNetSharp.Core/Layers/ConvLayer.cs
+++ b/src/ConvNetSharp.Core/Layers/ConvLayer.cs
@@ -24,6 +24,8 @@ namespace ConvNetSharp.Core.Layers
             this.Filters = BuilderInstance<T>.Volume.SameAs(data["Filters"].ToArrayOfT<T>(), new Shape(this.Width, this.Height, this.InputDepth, this.FilterCount));
             this.Bias = BuilderInstance<T>.Volume.SameAs(data["Bias"].ToArrayOfT<T>(), new Shape(1, 1, this.FilterCount));
             this.BiasPref = (T)Convert.ChangeType(data["BiasPref"], typeof(T));
+            this.FiltersGradient = BuilderInstance<T>.Volume.SameAs(data["FiltersGradient"].ToArrayOfT<T>(), new Shape(this.Width, this.Height, this.InputDepth, this.FilterCount));
+            this.BiasGradient = BuilderInstance<T>.Volume.SameAs(data["BiasGradient"].ToArrayOfT<T>(), new Shape(1, 1, this.FilterCount));
 
             this.IsInitialized = true;
         }
@@ -125,6 +127,8 @@ namespace ConvNetSharp.Core.Layers
             dico["Bias"] = this.Bias.ToArray();
             dico["Filters"] = this.Filters.ToArray();
             dico["BiasPref"] = this.BiasPref;
+            dico["FiltersGradient"] = this.FiltersGradient.ToArray();
+            dico["BiasGradient"] = this.BiasGradient.ToArray();
 
             return dico;
         }

--- a/src/ConvNetSharp.Core/Layers/FullyConnLayer.cs
+++ b/src/ConvNetSharp.Core/Layers/FullyConnLayer.cs
@@ -18,6 +18,8 @@ namespace ConvNetSharp.Core.Layers
             this.Filters = BuilderInstance<T>.Volume.SameAs(data["Filters"].ToArrayOfT<T>(), new Shape(1, 1, this.InputWidth * this.InputHeight * this.InputDepth, this.NeuronCount));
             this.Bias = BuilderInstance<T>.Volume.SameAs(data["Bias"].ToArrayOfT<T>(), new Shape(1, 1, this.NeuronCount));
             this.BiasPref = (T)Convert.ChangeType(data["BiasPref"], typeof(T));
+            this.BiasGradient = BuilderInstance<T>.Volume.SameAs(data["BiasGradient"].ToArrayOfT<T>(), new Shape(1, 1, this.NeuronCount));
+            this.FiltersGradient = BuilderInstance<T>.Volume.SameAs(data["FiltersGradient"].ToArrayOfT<T>(), new Shape(1, 1, this.InputWidth * this.InputHeight * this.InputDepth, this.NeuronCount));
             this.IsInitialized = true;
         }
 
@@ -83,6 +85,8 @@ namespace ConvNetSharp.Core.Layers
             dico["Bias"] = this.Bias.ToArray();
             dico["Filters"] = this.Filters.ToArray();
             dico["BiasPref"] = this.BiasPref;
+            dico["FiltersGradient"] = this.FiltersGradient.ToArray();
+            dico["BiasGradient"] = this.BiasGradient.ToArray();
 
             return dico;
         }


### PR DESCRIPTION
@cbovar due to missing FiltersGradient and BiasGradient after loading a saved json file, null reference error occurrs during training.