### PR TITLE
SGD trainer gpu optimization

### DIFF
--- a/ConvNetSharp.2015.sln
+++ b/ConvNetSharp.2015.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MnistDemo.2015", "Examples\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MnitsDemo.GPU.2015", "Examples\MnistDemo.GPU\MnitsDemo.GPU.2015.csproj", "{A8B66B25-6CE8-4B01-A622-D37D4A0029D0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConvNetSharp.Performance.Tests.2015", "src\ConvNetSharp.Performance.Tests\ConvNetSharp.Performance.Tests.2015.csproj", "{857A7B91-A10B-484D-9164-0850734A4583}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -77,6 +79,10 @@ Global
 		{A8B66B25-6CE8-4B01-A622-D37D4A0029D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A8B66B25-6CE8-4B01-A622-D37D4A0029D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A8B66B25-6CE8-4B01-A622-D37D4A0029D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{857A7B91-A10B-484D-9164-0850734A4583}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{857A7B91-A10B-484D-9164-0850734A4583}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{857A7B91-A10B-484D-9164-0850734A4583}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{857A7B91-A10B-484D-9164-0850734A4583}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ConvNetSharp.sln
+++ b/ConvNetSharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Demos", "Demos", "{52D65A64-6583-4C2B-A41B-009A739CCC80}"
 EndProject
@@ -26,6 +26,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MnistDemo", "Examples\MnistDemo\MnistDemo.csproj", "{CD073D54-06AC-46E2-BC9C-BB03BC98EC14}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MnitsDemo.GPU", "Examples\MnistDemo.GPU\MnitsDemo.GPU.csproj", "{1C5D92A1-272A-4545-BE0D-B4F836861E04}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConvNetSharp.Performance.Tests", "src\ConvNetSharp.Performance.Tests\ConvNetSharp.Performance.Tests.csproj", "{857A7B91-A10B-484D-9164-0850734A4583}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -77,6 +79,10 @@ Global
 		{1C5D92A1-272A-4545-BE0D-B4F836861E04}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1C5D92A1-272A-4545-BE0D-B4F836861E04}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1C5D92A1-272A-4545-BE0D-B4F836861E04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{857A7B91-A10B-484D-9164-0850734A4583}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{857A7B91-A10B-484D-9164-0850734A4583}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{857A7B91-A10B-484D-9164-0850734A4583}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{857A7B91-A10B-484D-9164-0850734A4583}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Examples/MnistDemo.GPU/Program.cs
+++ b/Examples/MnistDemo.GPU/Program.cs
@@ -76,9 +76,11 @@ namespace MnistDemo.GPU
                     Math.Round(this._trainAccWindow.Items.Average() * 100.0, 2),
                     Math.Round(this._testAccWindow.Items.Average() * 100.0, 2));
 
-                Console.WriteLine("Example seen: {0} Fwd: {1}ms Bckw: {2}ms", this._stepCount,
+                Console.WriteLine("Example seen: {0} Fwd: {1}ms Bckw: {2}ms Updt: {3}ms", this._stepCount,
                     Math.Round(this._trainer.ForwardTimeMs, 2),
-                    Math.Round(this._trainer.BackwardTimeMs, 2));
+                    Math.Round(this._trainer.BackwardTimeMs, 2),
+                    Math.Round(this._trainer.UpdateWeightsTimeMs, 2));
+
             } while (!Console.KeyAvailable);
         }
 

--- a/src/ConvNetSharp.Core/ConvNetSharp.Core.2015.csproj
+++ b/src/ConvNetSharp.Core/ConvNetSharp.Core.2015.csproj
@@ -31,7 +31,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/src/ConvNetSharp.Core/Ops.cs
+++ b/src/ConvNetSharp.Core/Ops.cs
@@ -8,6 +8,8 @@ namespace ConvNetSharp.Core
     {
         public static readonly Func<T, T, T> Add;
 
+        public static readonly Func<T, T, T> Subtract;
+
         public static readonly Func<T, T, T> Multiply;
 
         public static readonly Func<T, T, T> Divide;
@@ -22,7 +24,7 @@ namespace ConvNetSharp.Core
 
         public static readonly Func<T, T> Sqrt;
 
-        public static readonly Func<int, T> Cast;
+        public static readonly Func<double, T> Cast;
 
         public static readonly T Zero;
 
@@ -40,16 +42,15 @@ namespace ConvNetSharp.Core
             var addBody = Expression.Add(firstOperand, secondOperand);
             Add = Expression.Lambda<Func<T, T, T>>(addBody, firstOperand, secondOperand).Compile();
 
+            var subtractBody = Expression.Subtract(firstOperand, secondOperand);
+            Subtract = Expression.Lambda<Func<T, T, T>>(subtractBody, firstOperand, secondOperand).Compile();
+
             var multBody = Expression.Multiply(firstOperand, secondOperand);
             Multiply = Expression.Lambda<Func<T, T, T>>(multBody, firstOperand, secondOperand).Compile();
 
             var divBody = Expression.Divide(firstOperand, secondOperand);
             Divide = Expression.Lambda<Func<T, T, T>>(divBody, firstOperand, secondOperand).Compile();
-
-            var intOperand = Expression.Parameter(typeof(int), "x");
-            var castBody = Expression.Convert(intOperand, typeof(T));
-            Cast = Expression.Lambda<Func<int, T>>(castBody, intOperand).Compile();
-
+            
             //Log only exists as Math.Log(double x) so always to cast to and from double
             var logMethod = typeof(Math).GetRuntimeMethod("Log", new[] { typeof(T) });
             Log = Expression.Lambda<Func<T, T>>(
@@ -89,11 +90,18 @@ namespace ConvNetSharp.Core
             {
                 One = (T)(ValueType)1.0;
                 Epsilon = (T)(ValueType)double.Epsilon;
+
+                Expression<Func<T, T>> identity = e => e;
+                Cast = Expression.Lambda<Func<double, T>>(identity.Body, identity.Parameters[0]).Compile();
             }
             else if (typeof(T) == typeof(float))
             {
                 One = (T)(ValueType)1.0f;
                 Epsilon = (T)(ValueType)float.Epsilon;
+
+                var doubleOperand = Expression.Parameter(typeof(double), "x");
+                var castBody = Expression.Convert(doubleOperand, typeof(T));
+                Cast = Expression.Lambda<Func<double, T>>(castBody, doubleOperand).Compile();
             }
         }
     }

--- a/src/ConvNetSharp.Performance.Tests/App.config
+++ b/src/ConvNetSharp.Performance.Tests/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/src/ConvNetSharp.Performance.Tests/App.config
+++ b/src/ConvNetSharp.Performance.Tests/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
     </startup>
 </configuration>

--- a/src/ConvNetSharp.Performance.Tests/ConvNetSharp.Performance.Tests.2015.csproj
+++ b/src/ConvNetSharp.Performance.Tests/ConvNetSharp.Performance.Tests.2015.csproj
@@ -50,17 +50,17 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ConvNetSharp.Core\ConvNetSharp.Core.csproj">
+    <ProjectReference Include="..\ConvNetSharp.Core\ConvNetSharp.Core.2015.csproj">
       <Project>{3a6864af-30b4-4c0e-b621-3571e3d88b43}</Project>
-      <Name>ConvNetSharp.Core</Name>
+      <Name>ConvNetSharp.Core.2015</Name>
     </ProjectReference>
-    <ProjectReference Include="..\ConvNetSharp.Volume.GPU\ConvNetSharp.Volume.GPU.csproj">
-      <Project>{608c97db-721f-4b34-be2d-01a85b762be9}</Project>
-      <Name>ConvNetSharp.Volume.GPU</Name>
+    <ProjectReference Include="..\ConvNetSharp.Volume.GPU\ConvNetSharp.Volume.GPU.2015.csproj">
+      <Project>{bdcc5296-bfd4-411a-8f92-bf30ac85e0ba}</Project>
+      <Name>ConvNetSharp.Volume.GPU.2015</Name>
     </ProjectReference>
-    <ProjectReference Include="..\ConvNetSharp.Volume\ConvNetSharp.Volume.csproj">
+    <ProjectReference Include="..\ConvNetSharp.Volume\ConvNetSharp.Volume.2015.csproj">
       <Project>{1a285120-f2f0-4a94-ab31-b4e870679c0e}</Project>
-      <Name>ConvNetSharp.Volume</Name>
+      <Name>ConvNetSharp.Volume.2015</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/ConvNetSharp.Performance.Tests/ConvNetSharp.Performance.Tests.2015.csproj
+++ b/src/ConvNetSharp.Performance.Tests/ConvNetSharp.Performance.Tests.2015.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{857A7B91-A10B-484D-9164-0850734A4583}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConvNetSharp.Performance.Tests</RootNamespace>
+    <AssemblyName>ConvNetSharp.Performance.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ConvNetSharp.Core\ConvNetSharp.Core.csproj">
+      <Project>{3a6864af-30b4-4c0e-b621-3571e3d88b43}</Project>
+      <Name>ConvNetSharp.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ConvNetSharp.Volume.GPU\ConvNetSharp.Volume.GPU.csproj">
+      <Project>{608c97db-721f-4b34-be2d-01a85b762be9}</Project>
+      <Name>ConvNetSharp.Volume.GPU</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ConvNetSharp.Volume\ConvNetSharp.Volume.csproj">
+      <Project>{1a285120-f2f0-4a94-ab31-b4e870679c0e}</Project>
+      <Name>ConvNetSharp.Volume</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/ConvNetSharp.Performance.Tests/ConvNetSharp.Performance.Tests.csproj
+++ b/src/ConvNetSharp.Performance.Tests/ConvNetSharp.Performance.Tests.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{857A7B91-A10B-484D-9164-0850734A4583}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConvNetSharp.Performance.Tests</RootNamespace>
+    <AssemblyName>ConvNetSharp.Performance.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ConvNetSharp.Core\ConvNetSharp.Core.csproj">
+      <Project>{3a6864af-30b4-4c0e-b621-3571e3d88b43}</Project>
+      <Name>ConvNetSharp.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ConvNetSharp.Volume.GPU\ConvNetSharp.Volume.GPU.csproj">
+      <Project>{608c97db-721f-4b34-be2d-01a85b762be9}</Project>
+      <Name>ConvNetSharp.Volume.GPU</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ConvNetSharp.Volume\ConvNetSharp.Volume.csproj">
+      <Project>{1a285120-f2f0-4a94-ab31-b4e870679c0e}</Project>
+      <Name>ConvNetSharp.Volume</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/ConvNetSharp.Performance.Tests/Program.cs
+++ b/src/ConvNetSharp.Performance.Tests/Program.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using ConvNetSharp.Core;
+using ConvNetSharp.Core.Layers.Double;
+using ConvNetSharp.Core.Training.Double;
+using ConvNetSharp.Volume;
+
+namespace ConvNetSharp.Performance.Tests
+{
+    public class TestNet : Net<double>
+    {
+        public Shape[] InputShape { get; set; }
+        public Shape OutputShape { get; set; }
+    }
+
+    public class Set
+    {
+        public Volume<double>[] Inputs { get; set; }
+        public Volume<double> Outputs { get; set; }
+    }
+
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            var gpuVolumeBuilder = new Volume.GPU.Double.VolumeBuilder();
+            var cpuVolumeBuilder = new Volume.Double.VolumeBuilder();
+
+            BuilderInstance<double>.Volume = cpuVolumeBuilder;
+            var testNet = Create(20, 4, 4);
+            ExecuteNeuralNet("CPU", testNet, 100, 1000, 10);
+
+            BuilderInstance<double>.Volume = gpuVolumeBuilder;
+            testNet = Create(20, 4, 4);
+            ExecuteNeuralNet("GPU", testNet, 100, 1000, 10);
+        }
+
+        private static TestNet Create(int layerSize, int nmLayers, int inputWHD)
+        {
+            var net = new TestNet();
+            net.InputShape = new[] { Shape.From(inputWHD, inputWHD, inputWHD) };
+            net.OutputShape = Shape.From(1, 1, layerSize);
+            net.AddLayer(new InputLayer(inputWHD, inputWHD, inputWHD));
+            for (var i = 0; i < nmLayers; i++)
+            {
+                net.AddLayer(new FullyConnLayer(layerSize));
+                net.AddLayer(new SigmoidLayer());
+            }
+            net.AddLayer(new FullyConnLayer(layerSize));
+            net.AddLayer(new SoftmaxLayer(layerSize));
+            return net;
+        }
+
+        public static Set[] CreateSampleSets(
+            TestNet consumer,
+            int batchSize,
+            int totalSets)
+        {
+            var sets = new List<Set>();
+
+            var builder = BuilderInstance<double>.Volume;
+
+            for (var s = 0; s < totalSets; s += batchSize)
+            {
+                var batchInputs = consumer
+                    .InputShape
+                    .Select(inputShape =>
+                    {
+                        var inputBatch = Shape.From(inputShape, batchSize);
+                        return builder.Random(inputBatch);
+                    }).ToArray();
+
+                var outputShape = Shape.From(consumer.OutputShape, batchSize);
+                var tempBatchOutputs = builder.Random(outputShape);
+                var batchOutputs = builder.SameAs(outputShape);
+                tempBatchOutputs.DoSoftMax(batchOutputs);
+
+                sets.Add(new Set
+                {
+                    Inputs = batchInputs,
+                    Outputs = batchOutputs
+                });
+            }
+
+            return sets.ToArray();
+        }
+
+        private static void ExecuteNeuralNet(
+            string name,
+            TestNet net,
+            int batchSize,
+            int totalSets,
+            int iterations)
+        {
+            var inputs = CreateSampleSets(net, batchSize, totalSets);
+
+            var stopWatch = new Stopwatch();
+            Console.WriteLine($"- {name} ------");
+            stopWatch.Restart();
+
+            var trainer = new SgdTrainer(net);
+            trainer.LearningRate = 0.01;
+            trainer.Momentum = 0;
+            trainer.L1Decay = 0;
+            trainer.L2Decay = 0;
+            trainer.BatchSize = batchSize;
+
+            for (var i = 0; i < iterations; i++)
+            {
+                foreach (var set in inputs)
+                {
+                    trainer.Train(set.Inputs[0], set.Outputs);
+                }
+            }
+
+            stopWatch.Stop();
+
+            Console.WriteLine("    total: {0:0.000}ms", stopWatch.ElapsedMilliseconds);
+            Console.WriteLine("  forward: {0:0.000}ms", trainer.ForwardTimeMs);
+            Console.WriteLine(" backward: {0:0.000}ms", trainer.BackwardTimeMs);
+            Console.WriteLine("   update: {0:0.000}ms", trainer.UpdateWeightsTimeMs);
+        }
+    }
+}

--- a/src/ConvNetSharp.Performance.Tests/Properties/AssemblyInfo.cs
+++ b/src/ConvNetSharp.Performance.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ConvNetSharp.Performance.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ConvNetSharp.Performance.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("857a7b91-a10b-484d-9164-0850734a4583")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ConvNetSharp.Volume.GPU.Tests/DoubleVolumeTests.cs
+++ b/src/ConvNetSharp.Volume.GPU.Tests/DoubleVolumeTests.cs
@@ -647,6 +647,36 @@ namespace ConvNetSharp.Volume.GPU.Tests
         }
 
         [TestMethod]
+        public void Multiply()
+        {
+            var matrix = new[] { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+            var a = new Double.Volume(matrix, Shape.From(2, 2, 2), GpuContext.Default);
+            var b = a.Clone();
+
+            const double eps = 0.00001;
+
+            var result = b.Multiply(0.1);
+            Assert.AreNotSame(b, result);
+            Assert.AreNotSame(b.Storage, result.Storage);
+            for (var i = 0; i < matrix.Length; i++)
+            {
+                Assert.AreEqual(matrix[i], a.Get(i), eps);
+                Assert.AreEqual(matrix[i], b.Get(i), eps);
+                Assert.AreEqual(matrix[i] * 0.1, result.Get(i), eps);
+            }
+
+            b = result;
+            result = a.Clone();
+            a.DoMultiply(b, result);
+            for (var i = 0; i < matrix.Length; i++)
+            {
+                Assert.AreEqual(matrix[i], a.Get(i), eps);
+                Assert.AreEqual(matrix[i] * 0.1, b.Get(i), eps);
+                Assert.AreEqual(matrix[i] * matrix[i] * 0.1, result.Get(i), eps);
+            }
+        }
+
+        [TestMethod]
         public void ToArray()
         {
             var doubles = new[] { 1.0, 2.0, 3.0 };

--- a/src/ConvNetSharp.Volume.GPU.Tests/DoubleVolumeTests.cs
+++ b/src/ConvNetSharp.Volume.GPU.Tests/DoubleVolumeTests.cs
@@ -12,25 +12,39 @@ namespace ConvNetSharp.Volume.GPU.Tests
         public void Add1D()
         {
             var left = new Double.Volume(new[] { 1.0, 2.0, 3.0 }, new Shape(3), GpuContext.Default);
-            var right = new Double.Volume(new[] { 1.0, 2.0, 3.0 }, new Shape(3), GpuContext.Default);
+            var right = new Double.Volume(new[] { 0.1, 0.2, 0.3 }, new Shape(3), GpuContext.Default);
 
             var result = left + right;
-            Assert.AreEqual(2.0, result.Get(0));
-            Assert.AreEqual(4.0, result.Get(1));
-            Assert.AreEqual(6.0, result.Get(2));
+            Assert.AreEqual(1.1, result.Get(0));
+            Assert.AreEqual(2.2, result.Get(1));
+            Assert.AreEqual(3.3, result.Get(2));
         }
 
         [TestMethod]
         public void Add2D()
         {
             var left = new Double.Volume(new[] { 1.0, 2.0, 3.0, 4.0 }, new Shape(2, -1), GpuContext.Default);
-            var right = new Double.Volume(new[] { 1.0, 2.0, 3.0, 4.0 }, new Shape(2, -1), GpuContext.Default);
+            var right = new Double.Volume(new[] { 0.1, 0.2, 0.3, 0.4 }, new Shape(2, -1), GpuContext.Default);
 
             var result = left + right;
-            Assert.AreEqual(2.0, result.Get(0, 0));
-            Assert.AreEqual(4.0, result.Get(1, 0));
-            Assert.AreEqual(6.0, result.Get(0, 1));
-            Assert.AreEqual(8.0, result.Get(1, 1));
+            Assert.AreEqual(1.1, result.Get(0, 0));
+            Assert.AreEqual(2.2, result.Get(1, 0));
+            Assert.AreEqual(3.3, result.Get(0, 1));
+            Assert.AreEqual(4.4, result.Get(1, 1));
+        }
+
+        [TestMethod]
+        public void DoAddToSame()
+        {
+            var left = new Double.Volume(new[] { 1.0, 2.0, 3.0, 4.0 }, new Shape(2, -1), GpuContext.Default);
+            var right = new Double.Volume(new[] { 0.1, 0.2, 0.3, 0.4 }, new Shape(2, -1), GpuContext.Default);
+
+            right.DoAdd(left, right);
+
+            Assert.AreEqual(1.1, right.Get(0, 0));
+            Assert.AreEqual(2.2, right.Get(1, 0));
+            Assert.AreEqual(3.3, right.Get(0, 1));
+            Assert.AreEqual(4.4, right.Get(1, 1));
         }
 
         [TestMethod]
@@ -614,6 +628,33 @@ namespace ConvNetSharp.Volume.GPU.Tests
             Assert.AreEqual(-1.0, result.Get(0));
             Assert.AreEqual(2.0, result.Get(1));
             Assert.AreEqual(2.0, result.Get(2));
+        }
+
+        [TestMethod]
+        public void DoSubstractFrom()
+        {
+            var left = new Double.Volume(new[] { 1.0, 2.0, 3.0 }, new Shape(3), GpuContext.Default);
+            var right = new Double.Volume(new[] { 2.0, 0.0, 1.0 }, new Shape(3), GpuContext.Default);
+            var result = BuilderInstance<double>.Volume.SameAs(left.Shape);
+
+            right.DoSubtractFrom(left, result);
+
+            Assert.AreEqual(-1.0, result.Get(0));
+            Assert.AreEqual(2.0, result.Get(1));
+            Assert.AreEqual(2.0, result.Get(2));
+        }
+
+        [TestMethod]
+        public void DoSubstractFromInPlace()
+        {
+            var left = new Double.Volume(new[] { 1.0, 2.0, 3.0 }, new Shape(3), GpuContext.Default);
+            var right = new Double.Volume(new[] { 2.0, 0.0, 1.0 }, new Shape(3), GpuContext.Default);
+
+            right.DoSubtractFrom(left, left);
+
+            Assert.AreEqual(-1.0, left.Get(0));
+            Assert.AreEqual(2.0, left.Get(1));
+            Assert.AreEqual(2.0, left.Get(2));
         }
 
         [TestMethod]

--- a/src/ConvNetSharp.Volume.GPU.Tests/SingleVolumeTests.cs
+++ b/src/ConvNetSharp.Volume.GPU.Tests/SingleVolumeTests.cs
@@ -617,10 +617,12 @@ namespace ConvNetSharp.Volume.GPU.Tests
         {
             var left = new Single.Volume(new[] { 1.0f, 2.0f, 3.0f }, new Shape(3),
                 GpuContext.Default);
+
             var right = new Single.Volume(new[] { 2.0f, 0.0f, 1.0f }, new Shape(3),
                 GpuContext.Default);
 
             var result = left - right;
+
             Assert.AreEqual(-1.0f, result.Get(0));
             Assert.AreEqual(2.0f, result.Get(1));
             Assert.AreEqual(2.0f, result.Get(2));

--- a/src/ConvNetSharp.Volume.GPU.Tests/SingleVolumeTests.cs
+++ b/src/ConvNetSharp.Volume.GPU.Tests/SingleVolumeTests.cs
@@ -169,31 +169,6 @@ namespace ConvNetSharp.Volume.GPU.Tests
         }
 
         [TestMethod]
-        public void ConvolveGradient()
-        {
-            // 3x3x3x1
-            var input = new Single.Volume(new float[27].Populate(1.0f), new Shape(3, 3, 3, 1),
-                GpuContext.Default);
-
-            // 2x2x3x2
-            var filter = new Single.Volume(
-                new float[12].Populate(1.0f).Concat(new float[12].Populate(2.0f)).ToArray(),
-                new Shape(2, 2, 3, 2), GpuContext.Default);
-
-            var outputGradient = new Single.Volume(new[] { 2.0f, 3.0f }, new Shape(1, 1, 2, 1),
-                GpuContext.Default);
-
-            var inputGradient = BuilderInstance<float>.Volume.SameAs(input.Storage, input.Shape);
-            var filterGradient = BuilderInstance<float>.Volume.SameAs(filter.Storage, filter.Shape);
-
-            input.ConvolveGradient(filter, outputGradient, inputGradient, filterGradient, 0, 2);
-
-            Assert.AreEqual(8, inputGradient.Get(0, 0, 0, 0));
-            Assert.AreEqual(0, inputGradient.Get(2, 2, 2, 0));
-            Assert.AreEqual(0, inputGradient.Get(2, 2, 1, 0));
-        }
-
-        [TestMethod]
         public void Convolve()
         {
             // 3x3x3x1

--- a/src/ConvNetSharp.Volume.GPU/ConvNetSharp.Volume.GPU.csproj
+++ b/src/ConvNetSharp.Volume.GPU/ConvNetSharp.Volume.GPU.csproj
@@ -38,7 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedCuda-CudaDNN" Version="5.0.1" />
+    <PackageReference Include="ManagedCuda-80" Version="8.0.22" />
+    <PackageReference Include="ManagedCuda-CudaDNN" Version="8.0.22" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ConvNetSharp.Volume.GPU/Double/Volume.cs
+++ b/src/ConvNetSharp.Volume.GPU/Double/Volume.cs
@@ -62,8 +62,9 @@ namespace ConvNetSharp.Volume.GPU.Double
                 resultDesc.SetTensor4dDescriptor(cudnnTensorFormat.NCHW, cudnnDataType.Double, n, c, h, w);
                 activationDesc.SetActivationDescriptor(mode, cudnnNanPropagation.NotPropagateNan, 0.0);
 
-                this._context.CudnnContext.ActivationForward(activationDesc, 1.0, srcDesc, this._volumeStorage.DeviceBuffer, 0.0,
-                    resultDesc, resultStorage.DeviceBuffer);
+                this._context.CudnnContext.ActivationForward(activationDesc,
+                    1.0, srcDesc, this._volumeStorage.DeviceBuffer,
+                    0.0, resultDesc, resultStorage.DeviceBuffer);
             }
         }
 

--- a/src/ConvNetSharp.Volume.GPU/Double/Volume.cs
+++ b/src/ConvNetSharp.Volume.GPU/Double/Volume.cs
@@ -401,7 +401,7 @@ namespace ConvNetSharp.Volume.GPU.Double
             }
         }
 
-        protected override void DoMultiply(Volume<double> result, double factor)
+        public override void DoMultiply(Volume<double> result, double factor)
         {
             var resultStorage = result.Storage as VolumeStorage;
             if (resultStorage == null)

--- a/src/ConvNetSharp.Volume.GPU/Double/Volume.cs
+++ b/src/ConvNetSharp.Volume.GPU/Double/Volume.cs
@@ -62,7 +62,7 @@ namespace ConvNetSharp.Volume.GPU.Double
                 resultDesc.SetTensor4dDescriptor(cudnnTensorFormat.NCHW, cudnnDataType.Double, n, c, h, w);
                 activationDesc.SetActivationDescriptor(mode, cudnnNanPropagation.NotPropagateNan, 0.0);
 
-                this._context.CudnnContext.ActivationForward(activationDesc.Desc, 1.0, srcDesc, this._volumeStorage.DeviceBuffer, 0.0,
+                this._context.CudnnContext.ActivationForward(activationDesc, 1.0, srcDesc, this._volumeStorage.DeviceBuffer, 0.0,
                     resultDesc, resultStorage.DeviceBuffer);
             }
         }
@@ -129,14 +129,6 @@ namespace ConvNetSharp.Volume.GPU.Double
             // Copy to device if not already done
             this._volumeStorage.CopyToDevice();
             otherStorage.CopyToDevice();
-            resultStorage.CopyToDevice();
-
-            // result = this
-            DriverAPINativeMethods.SynchronousMemcpy_v2.cuMemcpy(resultStorage.DeviceBuffer.DevicePointer,
-                this._volumeStorage.DeviceBuffer.DevicePointer, this.Shape.TotalLength * sizeof(double));
-
-            // Synchro
-            this._context.DefaultStream.Synchronize();
 
             // Add tensors
             using (var biasDesc = new TensorDescriptor())

--- a/src/ConvNetSharp.Volume.GPU/Double/Volume.cs
+++ b/src/ConvNetSharp.Volume.GPU/Double/Volume.cs
@@ -127,7 +127,7 @@ namespace ConvNetSharp.Volume.GPU.Double
             }
 
             // Copy to device if not already done
-            this._volumeStorage.CopyToDevice();
+            resultStorage.CopyFrom(this._volumeStorage);
             otherStorage.CopyToDevice();
 
             // Add tensors
@@ -341,6 +341,66 @@ namespace ConvNetSharp.Volume.GPU.Double
             }
         }
 
+        public override void DoMultiply(Volume<double> right, Volume<double> result)
+        {
+            var resultStorage = result.Storage as VolumeStorage;
+            if (resultStorage == null)
+                throw new ArgumentException($"{nameof(result)} storage should be VolumeStorage", nameof(result));
+
+            if (!this.Shape.Equals(result.Shape))
+                throw new ArgumentException($"this and {nameof(result)} should be of same Shape!");
+
+            var rightStorage = right.Storage as VolumeStorage;
+            if (rightStorage == null)
+                throw new ArgumentException($"{nameof(right)} storage should be VolumeStorage", nameof(right));
+            
+            if (!this.Shape.Equals(right.Shape))
+                throw new ArgumentException($"this and {nameof(right)} should be of same Shape!");
+
+            // Copy to device if not already done
+            this._volumeStorage.CopyToDevice();
+            rightStorage.CopyToDevice();
+            resultStorage.CopyToDevice();
+
+            var n = this.Shape.GetDimension(3);
+            var c = this.Shape.GetDimension(2);
+            var h = this.Shape.GetDimension(1);
+            var w = this.Shape.GetDimension(0);
+
+            // Add tensors
+            using (var descA = new TensorDescriptor())
+            using (var descB = new TensorDescriptor())
+            using (var descC = new TensorDescriptor())
+            {
+                descA.SetTensor4dDescriptor(cudnnTensorFormat.NCHW, cudnnDataType.Double, n, c, h, w);
+                descB.SetTensor4dDescriptor(cudnnTensorFormat.NCHW, cudnnDataType.Double, n, c, h, w);
+                descC.SetTensor4dDescriptor(cudnnTensorFormat.NCHW, cudnnDataType.Double, n, c, h, w);
+
+                using (var opt = new OpTensorDescriptor(this._context.CudnnContext))
+                {
+                    opt.SetOpTensorDescriptor(
+                        cudnnOpTensorOp.OpTensorMul,
+                        cudnnDataType.Double,
+                        cudnnNanPropagation.NotPropagateNan);
+
+                    var one = 1.0;
+                    var zero = 0.0;
+
+                    var status = CudaDNNNativeMethods.cudnnOpTensor(
+                        this._context.CudnnContext.Handle,
+                        opt.Desc,
+                        ref one, descA.Desc, this._volumeStorage.DeviceBuffer.DevicePointer,
+                        ref one, descB.Desc, rightStorage.DeviceBuffer.DevicePointer,
+                        ref zero, descC.Desc, resultStorage.DeviceBuffer.DevicePointer);
+
+                    if (status != cudnnStatus.Success)
+                        throw new Exception(CudaDNNNativeMethods.cudnnGetErrorString(status));
+
+                    resultStorage.Location = DataLocation.Device;
+                }
+            }
+        }
+
         protected override void DoMultiply(Volume<double> result, double factor)
         {
             var resultStorage = result.Storage as VolumeStorage;
@@ -354,8 +414,10 @@ namespace ConvNetSharp.Volume.GPU.Double
             resultStorage.CopyToDevice();
 
             // result = this
-            DriverAPINativeMethods.SynchronousMemcpy_v2.cuMemcpy(resultStorage.DeviceBuffer.DevicePointer,
-                this._volumeStorage.DeviceBuffer.DevicePointer, this.Shape.TotalLength * sizeof(double));
+            DriverAPINativeMethods.SynchronousMemcpy_v2.cuMemcpy(
+                resultStorage.DeviceBuffer.DevicePointer,
+                this._volumeStorage.DeviceBuffer.DevicePointer,
+                this.Shape.TotalLength * sizeof(double));
 
             // Synchro
             this._context.DefaultStream.Synchronize();

--- a/src/ConvNetSharp.Volume.GPU/Double/VolumeStorage.cs
+++ b/src/ConvNetSharp.Volume.GPU/Double/VolumeStorage.cs
@@ -164,7 +164,40 @@ namespace ConvNetSharp.Volume.GPU.Double
             }
         }
 
-        public virtual void Dispose(bool disposing)
+        public override void CopyFrom(VolumeStorage<double> source)
+        {
+            var real = source as VolumeStorage;
+
+            if (!object.ReferenceEquals(this, real))
+            {
+                if (this.Shape.TotalLength != real.Shape.TotalLength)
+                    throw new ArgumentException($"{nameof(real)} has different length!");
+
+                real.CopyToDevice();
+
+                if (!this._allocatedOnDevice)
+                {
+                    this.DeviceBuffer = new CudaDeviceVariable<double>(this.Shape.TotalLength);
+                    this._allocatedOnDevice = true;
+                }
+
+                var res = DriverAPINativeMethods.SynchronousMemcpy_v2.cuMemcpy(
+                    this.DeviceBuffer.DevicePointer,
+                    real.DeviceBuffer.DevicePointer,
+                    this.Shape.TotalLength*sizeof(double));
+
+                if (res != CUResult.Success)
+                    throw new CudaException(res);
+
+                this.Location = DataLocation.Device;
+            }
+            else
+            {
+                this.CopyToDevice();
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
         {
             if (disposing)
             {
@@ -197,11 +230,6 @@ namespace ConvNetSharp.Volume.GPU.Double
             this.ConvolutionBackwardFilterStorage?.Dispose();
             this.ConvolutionBackwardStorage?.Dispose();
             this.ConvolutionStorage?.Dispose();
-        }
-
-        public override bool Equals(VolumeStorage<double> other)
-        {
-            throw new NotImplementedException();
         }
 
         ~VolumeStorage()

--- a/src/ConvNetSharp.Volume.GPU/Double/VolumeStorage.cs
+++ b/src/ConvNetSharp.Volume.GPU/Double/VolumeStorage.cs
@@ -92,6 +92,39 @@ namespace ConvNetSharp.Volume.GPU.Double
             Dispose(true);
         }
 
+        public override void CopyFrom(VolumeStorage<double> source)
+        {
+            var real = source as VolumeStorage;
+
+            if (!object.ReferenceEquals(this, real))
+            {
+                if (this.Shape.TotalLength != real.Shape.TotalLength)
+                    throw new ArgumentException($"{nameof(real)} has different length!");
+
+                real.CopyToDevice();
+
+                if (!this._allocatedOnDevice)
+                {
+                    this.DeviceBuffer = new CudaDeviceVariable<double>(this.Shape.TotalLength);
+                    this._allocatedOnDevice = true;
+                }
+
+                var res = DriverAPINativeMethods.SynchronousMemcpy_v2.cuMemcpy(
+                    this.DeviceBuffer.DevicePointer,
+                    real.DeviceBuffer.DevicePointer,
+                    this.Shape.TotalLength*sizeof(double));
+
+                if (res != CUResult.Success)
+                    throw new CudaException(res);
+
+                this.Location = DataLocation.Device;
+            }
+            else
+            {
+                this.CopyToDevice();
+            }
+        }
+
         public override void Clear()
         {
             switch (this.Location)
@@ -161,39 +194,6 @@ namespace ConvNetSharp.Volume.GPU.Double
                 this.Context.DefaultStream.Synchronize();
 
                 this.Location = DataLocation.Host;
-            }
-        }
-
-        public override void CopyFrom(VolumeStorage<double> source)
-        {
-            var real = source as VolumeStorage;
-
-            if (!object.ReferenceEquals(this, real))
-            {
-                if (this.Shape.TotalLength != real.Shape.TotalLength)
-                    throw new ArgumentException($"{nameof(real)} has different length!");
-
-                real.CopyToDevice();
-
-                if (!this._allocatedOnDevice)
-                {
-                    this.DeviceBuffer = new CudaDeviceVariable<double>(this.Shape.TotalLength);
-                    this._allocatedOnDevice = true;
-                }
-
-                var res = DriverAPINativeMethods.SynchronousMemcpy_v2.cuMemcpy(
-                    this.DeviceBuffer.DevicePointer,
-                    real.DeviceBuffer.DevicePointer,
-                    this.Shape.TotalLength*sizeof(double));
-
-                if (res != CUResult.Success)
-                    throw new CudaException(res);
-
-                this.Location = DataLocation.Device;
-            }
-            else
-            {
-                this.CopyToDevice();
             }
         }
 

--- a/src/ConvNetSharp.Volume.GPU/Single/Volume.cs
+++ b/src/ConvNetSharp.Volume.GPU/Single/Volume.cs
@@ -352,7 +352,7 @@ namespace ConvNetSharp.Volume.GPU.Single
             }
         }
 
-        protected override void DoMultiply(Volume<float> result, float factor)
+        public override void DoMultiply(Volume<float> result, float factor)
         {
             var resultStorage = result.Storage as VolumeStorage;
             if (resultStorage == null)

--- a/src/ConvNetSharp.Volume.GPU/Single/Volume.cs
+++ b/src/ConvNetSharp.Volume.GPU/Single/Volume.cs
@@ -264,14 +264,14 @@ namespace ConvNetSharp.Volume.GPU.Single
         {
             var inputStorage = this._volumeStorage;
             var outputGradientStorage = outputGradients.Storage as VolumeStorage;
-            var filterstorage = filters.Storage as VolumeStorage;
+            var filterStorage = filters.Storage as VolumeStorage;
             var inputGradientStorage = inputGradient.Storage as VolumeStorage;
             var filterGradientStorage = filterGradient.Storage as VolumeStorage;
 
             // Copy to device if not already done
             inputStorage.CopyToDevice();
             outputGradientStorage.CopyToDevice();
-            filterstorage.CopyToDevice();
+            filterStorage.CopyToDevice();
             inputGradientStorage.CopyToDevice();
             filterGradientStorage.CopyToDevice();
 
@@ -342,10 +342,13 @@ namespace ConvNetSharp.Volume.GPU.Single
                 {
                     this._volumeStorage.ConvolutionBackwardStorage = new CudaDeviceVariable<byte>(dataWorkspaceSize);
                 }
-                this._context.CudnnContext.ConvolutionBackwardData(1.0f, filterDesc, filterstorage.DeviceBuffer, dOutputDesc,
-                    outputGradientStorage.DeviceBuffer, convolutionDesc, 0.0f, dataAlgo,
-                    this._volumeStorage.ConvolutionBackwardStorage, dDataDesc,
-                    inputGradientStorage.DeviceBuffer);
+
+                this._context.CudnnContext.ConvolutionBackwardData(1.0f, 
+                    filterDesc, filterStorage.DeviceBuffer, 
+                    dOutputDesc, outputGradientStorage.DeviceBuffer, 
+                    convolutionDesc, dataAlgo, 
+                    this._volumeStorage.ConvolutionBackwardStorage, 0.0f,
+                    dDataDesc, inputGradientStorage.DeviceBuffer);
             }
         }
 

--- a/src/ConvNetSharp.Volume.GPU/Single/Volume.cs
+++ b/src/ConvNetSharp.Volume.GPU/Single/Volume.cs
@@ -378,10 +378,10 @@ namespace ConvNetSharp.Volume.GPU.Single
                     this._volumeStorage.ConvolutionBackwardStorage = new CudaDeviceVariable<byte>(dataWorkspaceSize);
                 }
 
-                this._context.CudnnContext.ConvolutionBackwardData(1.0f, 
-                    filterDesc, filterStorage.DeviceBuffer, 
-                    dOutputDesc, outputGradientStorage.DeviceBuffer, 
-                    convolutionDesc, dataAlgo, 
+                this._context.CudnnContext.ConvolutionBackwardData(1.0f,
+                    filterDesc, filterStorage.DeviceBuffer,
+                    dOutputDesc, outputGradientStorage.DeviceBuffer,
+                    convolutionDesc, dataAlgo,
                     this._volumeStorage.ConvolutionBackwardStorage, 0.0f,
                     dDataDesc, inputGradientStorage.DeviceBuffer);
             }

--- a/src/ConvNetSharp.Volume.GPU/Single/VolumeStorage.cs
+++ b/src/ConvNetSharp.Volume.GPU/Single/VolumeStorage.cs
@@ -94,7 +94,35 @@ namespace ConvNetSharp.Volume.GPU.Single
 
         public override void CopyFrom(VolumeStorage<float> source)
         {
-            throw new NotImplementedException();
+            var real = source as VolumeStorage;
+
+            if (!object.ReferenceEquals(this, real))
+            {
+                if (this.Shape.TotalLength != real.Shape.TotalLength)
+                    throw new ArgumentException($"{nameof(real)} has different length!");
+
+                real.CopyToDevice();
+
+                if (!this._allocatedOnDevice)
+                {
+                    this.DeviceBuffer = new CudaDeviceVariable<float>(this.Shape.TotalLength);
+                    this._allocatedOnDevice = true;
+                }
+
+                var res = DriverAPINativeMethods.SynchronousMemcpy_v2.cuMemcpy(
+                    this.DeviceBuffer.DevicePointer,
+                    real.DeviceBuffer.DevicePointer,
+                    this.Shape.TotalLength * sizeof(float));
+
+                if (res != CUResult.Success)
+                    throw new CudaException(res);
+
+                this.Location = DataLocation.Device;
+            }
+            else
+            {
+                this.CopyToDevice();
+            }
         }
 
         public override void Clear()

--- a/src/ConvNetSharp.Volume.GPU/Single/VolumeStorage.cs
+++ b/src/ConvNetSharp.Volume.GPU/Single/VolumeStorage.cs
@@ -232,11 +232,6 @@ namespace ConvNetSharp.Volume.GPU.Single
             this.ConvolutionStorage?.Dispose();
         }
 
-        public override bool Equals(VolumeStorage<float> other)
-        {
-            throw new NotImplementedException();
-        }
-
         ~VolumeStorage()
         {
             Dispose(false);

--- a/src/ConvNetSharp.Volume.GPU/Single/VolumeStorage.cs
+++ b/src/ConvNetSharp.Volume.GPU/Single/VolumeStorage.cs
@@ -92,6 +92,11 @@ namespace ConvNetSharp.Volume.GPU.Single
             Dispose(true);
         }
 
+        public override void CopyFrom(VolumeStorage<float> source)
+        {
+            throw new NotImplementedException();
+        }
+
         public override void Clear()
         {
             switch (this.Location)

--- a/src/ConvNetSharp.Volume.GPU/packages.config
+++ b/src/ConvNetSharp.Volume.GPU/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ManagedCuda-75-Standalone" version="7.5.7" targetFramework="net462" />
-  <package id="ManagedCuda-CudaDNN" version="5.0.1" targetFramework="net462" />
+  <package id="ManagedCuda-80" version="8.0.22" targetFramework="net462" />
+  <package id="ManagedCuda-CudaDNN" version="8.0.22" targetFramework="net462" />
 </packages>

--- a/src/ConvNetSharp.Volume/ConvNetSharp.Volume.csproj
+++ b/src/ConvNetSharp.Volume/ConvNetSharp.Volume.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.4;net45;net46</TargetFrameworks>

--- a/src/ConvNetSharp.Volume/Double/Volume.cs
+++ b/src/ConvNetSharp.Volume/Double/Volume.cs
@@ -158,7 +158,7 @@ namespace ConvNetSharp.Volume.Double
             this.Storage.Map(x => x * factor, result.Storage);
         }
 
-        protected override void DoNegate(Volume<double> volume)
+        public override void DoNegate(Volume<double> volume)
         {
             DoMultiply(volume, -1.0);
         }
@@ -367,6 +367,11 @@ namespace ConvNetSharp.Volume.Double
         {
             this.Storage.Map((output, outGradient) => (1.0 - output * output) * outGradient, outputGradient.Storage,
                 inputGradient.Storage);
+        }
+
+        public override void DoSubtractFrom(Volume<double> other, Volume<double> result)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/ConvNetSharp.Volume/Double/Volume.cs
+++ b/src/ConvNetSharp.Volume/Double/Volume.cs
@@ -371,7 +371,7 @@ namespace ConvNetSharp.Volume.Double
 
         public override void DoSubtractFrom(Volume<double> other, Volume<double> result)
         {
-            throw new NotImplementedException();
+            this.Storage.MapEx((x, y) => y - x, other.Storage, result.Storage);
         }
     }
 }

--- a/src/ConvNetSharp.Volume/Double/Volume.cs
+++ b/src/ConvNetSharp.Volume/Double/Volume.cs
@@ -373,5 +373,10 @@ namespace ConvNetSharp.Volume.Double
         {
             this.Storage.MapEx((x, y) => y - x, other.Storage, result.Storage);
         }
+
+        public override void DoMultiply(Volume<double> right, Volume<double> result)
+        {
+            this.Storage.MapEx((x, y) => x  * y, right.Storage, result.Storage);
+        }
     }
 }

--- a/src/ConvNetSharp.Volume/Double/Volume.cs
+++ b/src/ConvNetSharp.Volume/Double/Volume.cs
@@ -153,7 +153,7 @@ namespace ConvNetSharp.Volume.Double
             }
         }
 
-        protected override void DoMultiply(Volume<double> result, double factor)
+        public override void DoMultiply(Volume<double> result, double factor)
         {
             this.Storage.Map(x => x * factor, result.Storage);
         }

--- a/src/ConvNetSharp.Volume/NcwhVolumeStorage.cs
+++ b/src/ConvNetSharp.Volume/NcwhVolumeStorage.cs
@@ -103,5 +103,12 @@ namespace ConvNetSharp.Volume
         {
             return (T[])this._storage.Clone();
         }
+
+        public override void CopyFrom(VolumeStorage<T> source)
+        {
+            var real = source as NcwhVolumeStorage<T>;
+
+            Array.Copy(real._storage, this._storage, this._storage.Length);
+        }
     }
 }

--- a/src/ConvNetSharp.Volume/NcwhVolumeStorage.cs
+++ b/src/ConvNetSharp.Volume/NcwhVolumeStorage.cs
@@ -103,15 +103,5 @@ namespace ConvNetSharp.Volume
         {
             return (T[])this._storage.Clone();
         }
-
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as VolumeStorage<T>);
-        }
-
-        public override bool Equals(VolumeStorage<T> other)
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/src/ConvNetSharp.Volume/Shape.cs
+++ b/src/ConvNetSharp.Volume/Shape.cs
@@ -66,6 +66,19 @@ namespace ConvNetSharp.Volume
             return true;
         }
 
+        public static Shape From(params int[] dimensions)
+        {
+            return new Shape(dimensions);
+        }
+
+        public static Shape From(Shape original, params int[] dimensions)
+        {
+            dimensions = original._dimensions
+                .Concat(dimensions)
+                .ToArray();
+            return new Shape(dimensions);
+        }
+
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj))

--- a/src/ConvNetSharp.Volume/Single/Volume.cs
+++ b/src/ConvNetSharp.Volume/Single/Volume.cs
@@ -161,9 +161,14 @@ namespace ConvNetSharp.Volume.Single
             this.Storage.Map(x => x * factor, result.Storage);
         }
 
-        protected override void DoNegate(Volume<float> volume)
+        public override void DoMultiply(Volume<float> right, Volume<float> result)
         {
-            DoMultiply(volume, -1.0f);
+            this.Storage.MapEx((x, y) => x * y, right.Storage, result.Storage);
+        }
+
+        public override void DoNegate(Volume<float> result)
+        {
+            DoMultiply(result, -1.0f);
         }
 
         public override void DoPool(Volume<float> result, int windowWidth, int windowHeight,
@@ -366,6 +371,11 @@ namespace ConvNetSharp.Volume.Single
         public override void DoTanhGradient(Volume<float> input, Volume<float> outputGradient, Volume<float> inputGradient)
         {
             this.Storage.Map((output, outGradient) => (1.0f - output * output) * outGradient, outputGradient.Storage, inputGradient.Storage);
+        }
+
+        public override void DoSubtractFrom(Volume<float> other, Volume<float> result)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/ConvNetSharp.Volume/Single/Volume.cs
+++ b/src/ConvNetSharp.Volume/Single/Volume.cs
@@ -156,7 +156,7 @@ namespace ConvNetSharp.Volume.Single
             }
         }
 
-        protected override void DoMultiply(Volume<float> result, float factor)
+        public override void DoMultiply(Volume<float> result, float factor)
         {
             this.Storage.Map(x => x * factor, result.Storage);
         }

--- a/src/ConvNetSharp.Volume/Single/Volume.cs
+++ b/src/ConvNetSharp.Volume/Single/Volume.cs
@@ -375,7 +375,7 @@ namespace ConvNetSharp.Volume.Single
 
         public override void DoSubtractFrom(Volume<float> other, Volume<float> result)
         {
-            throw new NotImplementedException();
+            this.Storage.MapEx((x, y) => y - x, other.Storage, result.Storage);
         }
     }
 }

--- a/src/ConvNetSharp.Volume/Volume.cs
+++ b/src/ConvNetSharp.Volume/Volume.cs
@@ -84,7 +84,7 @@ namespace ConvNetSharp.Volume
             Volume<T> inputGradient,
             Volume<T> filterGradient, int pad, int stride);
 
-        protected abstract void DoMultiply(Volume<T> result, T factor);
+        public abstract void DoMultiply(Volume<T> result, T factor);
 
         protected abstract void DoNegate(Volume<T> result);
 

--- a/src/ConvNetSharp.Volume/Volume.cs
+++ b/src/ConvNetSharp.Volume/Volume.cs
@@ -86,7 +86,11 @@ namespace ConvNetSharp.Volume
 
         public abstract void DoMultiply(Volume<T> result, T factor);
 
-        protected abstract void DoNegate(Volume<T> result);
+        public abstract void DoMultiply(Volume<T> right, Volume<T> result);
+
+        public abstract void DoSubtractFrom(Volume<T> other, Volume<T> result);
+
+        public abstract void DoNegate(Volume<T> result);
 
         public abstract void DoPool(Volume<T> result, int windowWidth, int windowHeight,
             int horizontalPad, int verticalPad, int horizontalStride, int verticalStride);
@@ -106,13 +110,7 @@ namespace ConvNetSharp.Volume
         public abstract void DoSoftMax(Volume<T> result);
 
         public abstract void DoSoftMaxGradient(Volume<T> outputGradient, Volume<T> inputGradient);
-
-        public void DoSubtractFrom(Volume<T> other, Volume<T> result)
-        {
-            DoNegate(result);
-            result.DoAdd(other, result);
-        }
-
+        
         public abstract void DoTanh(Volume<T> result);
 
         public abstract void DoTanhGradient(Volume<T> input, Volume<T> outputGradient, Volume<T> inputGradient);
@@ -155,7 +153,7 @@ namespace ConvNetSharp.Volume
             this.Storage.MapInplace(f, other.Storage);
         }
 
-        private Volume<T> Multiply(T factor)
+        public Volume<T> Multiply(T factor)
         {
             var result = BuilderInstance<T>.Volume.SameAs(this.Storage, this.Shape);
             DoMultiply(result, factor);

--- a/src/ConvNetSharp.Volume/Volume.cs
+++ b/src/ConvNetSharp.Volume/Volume.cs
@@ -25,10 +25,6 @@ namespace ConvNetSharp.Volume
                 throw new ArgumentException("Both volume should have the same shape.");
             }
 
-            if (sameChannels)
-            {
-            }
-
             var result = BuilderInstance<T>.Volume.SameAs(this.Storage, this.Shape);
             DoAdd(other, result);
             return result;

--- a/src/ConvNetSharp.Volume/VolumeStorage.cs
+++ b/src/ConvNetSharp.Volume/VolumeStorage.cs
@@ -25,6 +25,8 @@ namespace ConvNetSharp.Volume
 
         public abstract T Get(int i);
 
+        public abstract void CopyFrom(VolumeStorage<T> source);
+
         public void Map(Func<T, T, T> f, VolumeStorage<T> other, VolumeStorage<T> result)
         {
             for (var i = 0; i < this.Shape.TotalLength; i++)

--- a/src/ConvNetSharp.Volume/VolumeStorage.cs
+++ b/src/ConvNetSharp.Volume/VolumeStorage.cs
@@ -2,7 +2,7 @@
 
 namespace ConvNetSharp.Volume
 {
-    public abstract class VolumeStorage<T> : IEquatable<VolumeStorage<T>> where T : struct, IEquatable<T>, IFormattable
+    public abstract class VolumeStorage<T> where T : struct, IEquatable<T>, IFormattable
     {
         protected VolumeStorage(Shape shape)
         {
@@ -10,8 +10,6 @@ namespace ConvNetSharp.Volume
         }
 
         public Shape Shape { get; set; }
-
-        public abstract bool Equals(VolumeStorage<T> other);
 
         public abstract void Clear();
 


### PR DESCRIPTION
I modified SGD to update weights using native CudaDNN methods, and not to use Map or MapInPlace. Those methods cause too much memory copying and CPU usage. Performance boost is very noticeable.