### PR TITLE
Fix memory leak

### DIFF
--- a/src/ConvNetSharp.Core/Training/SgdTrainer.cs
+++ b/src/ConvNetSharp.Core/Training/SgdTrainer.cs
@@ -8,7 +8,7 @@ namespace ConvNetSharp.Core.Training
     ///     Stochastic gradient descent
     /// TODO: L1DecayLoss, L2DecayLoss
     /// </summary>
-    public class SgdTrainer<T> : TrainerBase<T> where T : struct, IEquatable<T>, IFormattable
+    public class SgdTrainer<T> : TrainerBase<T>, IDisposable where T : struct, IEquatable<T>, IFormattable
     {
         // last iteration gradients (used for momentum calculations)
         private readonly List<Volume<T>> velocities = new List<Volume<T>>();
@@ -30,6 +30,16 @@ namespace ConvNetSharp.Core.Training
         public T L1DecayLoss { get; private set; }
 
         public T LearningRate { get; set; }
+
+        public void Dispose()
+        {
+            foreach (var v in velocities)
+                v.Dispose();
+            foreach (var d in deltas)
+                d.Dispose();
+            foreach (var r in regGrads)
+                r.Dispose();
+        }
 
         protected override void Backward(Volume<T> y)
         {

--- a/src/ConvNetSharp.Volume.GPU/Double/Volume.cs
+++ b/src/ConvNetSharp.Volume.GPU/Double/Volume.cs
@@ -27,7 +27,7 @@ namespace ConvNetSharp.Volume.GPU.Double
             this._context = context;
             this._volumeStorage = this.Storage as VolumeStorage;
         }
-        
+
         private void DoActivation(Volume<double> result, cudnnActivationMode mode)
         {
             var resultStorage = result.Storage as VolumeStorage;

--- a/src/ConvNetSharp.Volume.GPU/Double/Volume.cs
+++ b/src/ConvNetSharp.Volume.GPU/Double/Volume.cs
@@ -27,12 +27,7 @@ namespace ConvNetSharp.Volume.GPU.Double
             this._context = context;
             this._volumeStorage = this.Storage as VolumeStorage;
         }
-
-        public void Dispose()
-        {
-            this._volumeStorage?.Dispose();
-        }
-
+        
         private void DoActivation(Volume<double> result, cudnnActivationMode mode)
         {
             var resultStorage = result.Storage as VolumeStorage;

--- a/src/ConvNetSharp.Volume.GPU/Double/Volume.cs
+++ b/src/ConvNetSharp.Volume.GPU/Double/Volume.cs
@@ -281,7 +281,8 @@ namespace ConvNetSharp.Volume.GPU.Double
                     convolutionDesc, outputDesc, algo);
                 workspaceSize = workspaceSize == 0 ? new SizeT(1) : workspaceSize;
 
-                if (this._volumeStorage.ConvolutionStorage == null || this._volumeStorage.ConvolutionStorage.Size != workspaceSize)
+                if (this._volumeStorage.ConvolutionStorage == null ||
+                    this._volumeStorage.ConvolutionStorage.Size != workspaceSize)
                 {
                     this._volumeStorage.ConvolutionStorage = new CudaDeviceVariable<byte>(workspaceSize);
                 }

--- a/src/ConvNetSharp.Volume.GPU/Double/VolumeStorage.cs
+++ b/src/ConvNetSharp.Volume.GPU/Double/VolumeStorage.cs
@@ -8,6 +8,7 @@ namespace ConvNetSharp.Volume.GPU.Double
 {
     public unsafe class VolumeStorage : VolumeStorage<double>, IDisposable
     {
+        private bool _disposed;
         private readonly IntPtr _hostPointer;
         private readonly bool _isOwner;
         private bool _allocatedOnDevice;
@@ -94,6 +95,8 @@ namespace ConvNetSharp.Volume.GPU.Double
 
         public override void CopyFrom(VolumeStorage<double> source)
         {
+            Debug.Assert(!_disposed);
+
             var real = source as VolumeStorage;
 
             if (!object.ReferenceEquals(this, real))
@@ -127,6 +130,8 @@ namespace ConvNetSharp.Volume.GPU.Double
 
         public override void Clear()
         {
+            Debug.Assert(!_disposed);
+
             switch (this.Location)
             {
                 case DataLocation.Host:
@@ -153,6 +158,8 @@ namespace ConvNetSharp.Volume.GPU.Double
 
         public void CopyToDevice()
         {
+            Debug.Assert(!_disposed);
+
             if (this.Location == DataLocation.Host)
             {
                 // Device 
@@ -179,6 +186,8 @@ namespace ConvNetSharp.Volume.GPU.Double
 
         public void CopyToHost()
         {
+            Debug.Assert(!_disposed);
+
             if (this.Location == DataLocation.Device)
             {
                 var res = DriverAPINativeMethods.AsynchronousMemcpy_v2.cuMemcpyDtoHAsync_v2(
@@ -196,9 +205,11 @@ namespace ConvNetSharp.Volume.GPU.Double
                 this.Location = DataLocation.Host;
             }
         }
-
+        
         protected virtual void Dispose(bool disposing)
         {
+            _disposed = true;
+
             if (disposing)
             {
                 GC.SuppressFinalize(this);

--- a/src/ConvNetSharp.Volume.GPU/Double/VolumeStorage.cs
+++ b/src/ConvNetSharp.Volume.GPU/Double/VolumeStorage.cs
@@ -11,32 +11,39 @@ namespace ConvNetSharp.Volume.GPU.Double
         private bool _disposed;
         private readonly IntPtr _hostPointer;
         private readonly bool _isOwner;
-        private bool _allocatedOnDevice;
 
+        public CudaDeviceVariable<byte> ConvolutionBackwardFilterStorage { get; set; }
+
+        public CudaDeviceVariable<byte> ConvolutionBackwardStorage { get; set; }
+
+        public CudaDeviceVariable<byte> ConvolutionStorage { get; set; }
+
+        public DataLocation Location { get; set; }
+
+        public double* HostBuffer { get; private set; }
+
+        public CudaDeviceVariable<double> DeviceBuffer { get; private set; }
+
+        public GpuContext Context { get; }
+        
         public VolumeStorage(Shape shape, GpuContext context, long length = -1) : base(shape)
         {
             this.Context = context;
 
             // Take care of unkown dimension
             if (length != -1)
-            {
                 this.Shape.GuessUnkownDimension(length);
-            }
 
             // Host 
             this._hostPointer = IntPtr.Zero;
             var res = DriverAPINativeMethods.MemoryManagement.cuMemAllocHost_v2(ref this._hostPointer, this.Shape.TotalLength * sizeof(double));
             if (res != CUResult.Success)
-            {
                 throw new CudaException(res);
-            }
-            this.HostBuffer = (double*)this._hostPointer;
 
+            this.HostBuffer = (double*)this._hostPointer;
             // Zero out
             for (var i = 0; i < this.Shape.TotalLength; i++)
-            {
                 this.HostBuffer[i] = 0.0;
-            }
 
             this._isOwner = true;
         }
@@ -59,38 +66,18 @@ namespace ConvNetSharp.Volume.GPU.Double
             this.Location = DataLocation.Host;
         }
 
-        public VolumeStorage(VolumeStorage storage, Shape shape)
-            : this(shape, storage.Context, storage.Shape.TotalLength)
+        public VolumeStorage(VolumeStorage storage, Shape newShape) : base(newShape)
         {
             this._isOwner = false;
-            this.Location = storage.Location;
-            this.HostBuffer = storage.HostBuffer;
             this._hostPointer = storage._hostPointer;
-            this._allocatedOnDevice = storage._allocatedOnDevice;
+            this.Shape = newShape;
+            this.HostBuffer = storage.HostBuffer;
+            this.Context = storage.Context;
 
             storage.CopyToDevice();
-            this.DeviceBuffer = new CudaDeviceVariable<double>(storage.DeviceBuffer.DevicePointer);
 
             this.Location = DataLocation.Device;
-        }
-
-        public CudaDeviceVariable<byte> ConvolutionBackwardFilterStorage { get; set; }
-
-        public CudaDeviceVariable<byte> ConvolutionBackwardStorage { get; set; }
-
-        public CudaDeviceVariable<byte> ConvolutionStorage { get; set; }
-
-        public DataLocation Location { get; set; }
-
-        public double* HostBuffer { get; private set; }
-
-        public CudaDeviceVariable<double> DeviceBuffer { get; private set; }
-
-        public GpuContext Context { get; }
-
-        public void Dispose()
-        {
-            Dispose(true);
+            this.DeviceBuffer = new CudaDeviceVariable<double>(storage.DeviceBuffer.DevicePointer);
         }
 
         public override void CopyFrom(VolumeStorage<double> source)
@@ -106,16 +93,13 @@ namespace ConvNetSharp.Volume.GPU.Double
 
                 real.CopyToDevice();
 
-                if (!this._allocatedOnDevice)
-                {
+                if (this.DeviceBuffer == null)
                     this.DeviceBuffer = new CudaDeviceVariable<double>(this.Shape.TotalLength);
-                    this._allocatedOnDevice = true;
-                }
 
                 var res = DriverAPINativeMethods.SynchronousMemcpy_v2.cuMemcpy(
                     this.DeviceBuffer.DevicePointer,
                     real.DeviceBuffer.DevicePointer,
-                    this.Shape.TotalLength*sizeof(double));
+                    this.Shape.TotalLength * sizeof(double));
 
                 if (res != CUResult.Success)
                     throw new CudaException(res);
@@ -128,6 +112,11 @@ namespace ConvNetSharp.Volume.GPU.Double
             }
         }
 
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+        
         public override void Clear()
         {
             Debug.Assert(!_disposed);
@@ -163,19 +152,15 @@ namespace ConvNetSharp.Volume.GPU.Double
             if (this.Location == DataLocation.Host)
             {
                 // Device 
-                if (!this._allocatedOnDevice)
-                {
+                if (this.DeviceBuffer == null)
                     this.DeviceBuffer = new CudaDeviceVariable<double>(this.Shape.TotalLength);
-                    this._allocatedOnDevice = true;
-                }
 
                 var res = DriverAPINativeMethods.AsynchronousMemcpy_v2.cuMemcpyHtoDAsync_v2(
                     this.DeviceBuffer.DevicePointer, this._hostPointer, this.DeviceBuffer.SizeInBytes,
                     this.Context.DefaultStream.Stream);
+
                 if (res != CUResult.Success)
-                {
                     throw new CudaException(res);
-                }
 
                 // Synchro
                 this.Context.DefaultStream.Synchronize();
@@ -195,9 +180,7 @@ namespace ConvNetSharp.Volume.GPU.Double
                     this.DeviceBuffer.DevicePointer, this.DeviceBuffer.SizeInBytes, this.Context.DefaultStream.Stream);
 
                 if (res != CUResult.Success)
-                {
                     throw new CudaException(res);
-                }
 
                 // Synchro
                 this.Context.DefaultStream.Synchronize();
@@ -205,7 +188,7 @@ namespace ConvNetSharp.Volume.GPU.Double
                 this.Location = DataLocation.Host;
             }
         }
-        
+
         protected virtual void Dispose(bool disposing)
         {
             _disposed = true;
@@ -219,24 +202,16 @@ namespace ConvNetSharp.Volume.GPU.Double
             {
                 var tmp = new IntPtr(this.HostBuffer);
                 this.HostBuffer = default(double*);
-
                 if (this._isOwner)
                 {
-                    try
-                    {
-                        DriverAPINativeMethods.MemoryManagement.cuMemFreeHost(tmp);
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.WriteLine(ex.Message);
-                    }
+                    DriverAPINativeMethods.MemoryManagement.cuMemFreeHost(tmp);
                 }
             }
 
             if (this._isOwner)
-            {
                 this.DeviceBuffer?.Dispose();
-            }
+            else
+                this.DeviceBuffer = null;
 
             this.ConvolutionBackwardFilterStorage?.Dispose();
             this.ConvolutionBackwardStorage?.Dispose();

--- a/src/ConvNetSharp.Volume.GPU/Double/VolumeStorage.cs
+++ b/src/ConvNetSharp.Volume.GPU/Double/VolumeStorage.cs
@@ -41,6 +41,7 @@ namespace ConvNetSharp.Volume.GPU.Double
                 throw new CudaException(res);
 
             this.HostBuffer = (double*)this._hostPointer;
+
             // Zero out
             for (var i = 0; i < this.Shape.TotalLength; i++)
                 this.HostBuffer[i] = 0.0;

--- a/src/ConvNetSharp.Volume.GPU/Single/Volume.cs
+++ b/src/ConvNetSharp.Volume.GPU/Single/Volume.cs
@@ -28,11 +28,6 @@ namespace ConvNetSharp.Volume.GPU.Single
             this._volumeStorage = this.Storage as VolumeStorage;
         }
 
-        public void Dispose()
-        {
-            this._volumeStorage?.Dispose();
-        }
-
         private void DoActivation(Volume<float> result, cudnnActivationMode mode)
         {
             var resultStorage = result.Storage as VolumeStorage;
@@ -62,8 +57,9 @@ namespace ConvNetSharp.Volume.GPU.Single
                 resultDesc.SetTensor4dDescriptor(cudnnTensorFormat.NCHW, cudnnDataType.Float, n, c, h, w);
                 activationDesc.SetActivationDescriptor(mode, cudnnNanPropagation.NotPropagateNan, 0.0);
 
-                this._context.CudnnContext.ActivationForward(activationDesc, 1.0f, srcDesc, this._volumeStorage.DeviceBuffer, 0.0f,
-                    resultDesc, resultStorage.DeviceBuffer);
+                this._context.CudnnContext.ActivationForward(activationDesc, 
+					1.0f, srcDesc, this._volumeStorage.DeviceBuffer, 
+					0.0f, resultDesc, resultStorage.DeviceBuffer);
             }
         }
 

--- a/src/ConvNetSharp.Volume.GPU/Single/VolumeStorage.cs
+++ b/src/ConvNetSharp.Volume.GPU/Single/VolumeStorage.cs
@@ -11,32 +11,40 @@ namespace ConvNetSharp.Volume.GPU.Single
         private bool _disposed;
         private readonly IntPtr _hostPointer;
         private readonly bool _isOwner;
-        private bool _allocatedOnDevice;
 
+        public CudaDeviceVariable<byte> ConvolutionBackwardFilterStorage { get; set; }
+
+        public CudaDeviceVariable<byte> ConvolutionBackwardStorage { get; set; }
+
+        public CudaDeviceVariable<byte> ConvolutionStorage { get; set; }
+
+        public DataLocation Location { get; set; }
+
+        public float* HostBuffer { get; private set; }
+
+        public CudaDeviceVariable<float> DeviceBuffer { get; private set; }
+
+        public GpuContext Context { get; }
+        
         public VolumeStorage(Shape shape, GpuContext context, long length = -1) : base(shape)
         {
             this.Context = context;
 
             // Take care of unkown dimension
             if (length != -1)
-            {
                 this.Shape.GuessUnkownDimension(length);
-            }
 
             // Host 
             this._hostPointer = IntPtr.Zero;
             var res = DriverAPINativeMethods.MemoryManagement.cuMemAllocHost_v2(ref this._hostPointer, this.Shape.TotalLength * sizeof(double));
             if (res != CUResult.Success)
-            {
                 throw new CudaException(res);
-            }
+
             this.HostBuffer = (float*)this._hostPointer;
 
             // Zero out
             for (var i = 0; i < this.Shape.TotalLength; i++)
-            {
                 this.HostBuffer[i] = 0.0f;
-            }
 
             this._isOwner = true;
         }
@@ -59,39 +67,19 @@ namespace ConvNetSharp.Volume.GPU.Single
             this.Location = DataLocation.Host;
         }
 
-        public VolumeStorage(VolumeStorage storage, Shape shape)
-            : this(shape, storage.Context, storage.Shape.TotalLength)
+		public VolumeStorage(VolumeStorage storage, Shape newShape) : base(newShape)
         {
             this._isOwner = false;
-            this.Location = storage.Location;
-            this.HostBuffer = storage.HostBuffer;
             this._hostPointer = storage._hostPointer;
-            this._allocatedOnDevice = storage._allocatedOnDevice;
+            this.Shape = newShape;
+            this.HostBuffer = storage.HostBuffer;
+            this.Context = storage.Context;
 
             storage.CopyToDevice();
-            this.DeviceBuffer = new CudaDeviceVariable<float>(storage.DeviceBuffer.DevicePointer);
 
             this.Location = DataLocation.Device;
-        }
-
-        public CudaDeviceVariable<byte> ConvolutionBackwardFilterStorage { get; set; }
-
-        public CudaDeviceVariable<byte> ConvolutionBackwardStorage { get; set; }
-
-        public CudaDeviceVariable<byte> ConvolutionStorage { get; set; }
-
-        public DataLocation Location { get; set; }
-
-        public float* HostBuffer { get; private set; }
-
-        public CudaDeviceVariable<float> DeviceBuffer { get; private set; }
-
-        public GpuContext Context { get; }
-
-        public void Dispose()
-        {
-            Dispose(true);
-        }
+            this.DeviceBuffer = new CudaDeviceVariable<float>(storage.DeviceBuffer.DevicePointer);
+        }        
 
         public override void CopyFrom(VolumeStorage<float> source)
         {
@@ -106,11 +94,8 @@ namespace ConvNetSharp.Volume.GPU.Single
 
                 real.CopyToDevice();
 
-                if (!this._allocatedOnDevice)
-                {
+                if (this.DeviceBuffer == null)
                     this.DeviceBuffer = new CudaDeviceVariable<float>(this.Shape.TotalLength);
-                    this._allocatedOnDevice = true;
-                }
 
                 var res = DriverAPINativeMethods.SynchronousMemcpy_v2.cuMemcpy(
                     this.DeviceBuffer.DevicePointer,
@@ -128,6 +113,11 @@ namespace ConvNetSharp.Volume.GPU.Single
             }
         }
 
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+        
         public override void Clear()
         {
             Debug.Assert(!_disposed);
@@ -163,19 +153,15 @@ namespace ConvNetSharp.Volume.GPU.Single
             if (this.Location == DataLocation.Host)
             {
                 // Device 
-                if (!this._allocatedOnDevice)
-                {
+                if (this.DeviceBuffer == null)
                     this.DeviceBuffer = new CudaDeviceVariable<float>(this.Shape.TotalLength);
-                    this._allocatedOnDevice = true;
-                }
 
                 var res = DriverAPINativeMethods.AsynchronousMemcpy_v2.cuMemcpyHtoDAsync_v2(
                     this.DeviceBuffer.DevicePointer, this._hostPointer, this.DeviceBuffer.SizeInBytes,
                     this.Context.DefaultStream.Stream);
+
                 if (res != CUResult.Success)
-                {
                     throw new CudaException(res);
-                }
 
                 // Synchro
                 this.Context.DefaultStream.Synchronize();
@@ -204,7 +190,7 @@ namespace ConvNetSharp.Volume.GPU.Single
             }
         }
 
-        public virtual void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
             _disposed = true;
 
@@ -217,24 +203,16 @@ namespace ConvNetSharp.Volume.GPU.Single
             {
                 var tmp = new IntPtr(this.HostBuffer);
                 this.HostBuffer = default(float*);
-
                 if (this._isOwner)
                 {
-                    try
-                    {
-                        DriverAPINativeMethods.MemoryManagement.cuMemFreeHost(tmp);
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.WriteLine(ex.Message);
-                    }
+                    DriverAPINativeMethods.MemoryManagement.cuMemFreeHost(tmp);
                 }
             }
 
             if (this._isOwner)
-            {
                 this.DeviceBuffer?.Dispose();
-            }
+            else
+                this.DeviceBuffer = null;
 
             this.ConvolutionBackwardFilterStorage?.Dispose();
             this.ConvolutionBackwardStorage?.Dispose();

--- a/src/ConvNetSharp.Volume.GPU/Single/VolumeStorage.cs
+++ b/src/ConvNetSharp.Volume.GPU/Single/VolumeStorage.cs
@@ -8,6 +8,7 @@ namespace ConvNetSharp.Volume.GPU.Single
 {
     public unsafe class VolumeStorage : VolumeStorage<float>, IDisposable
     {
+        private bool _disposed;
         private readonly IntPtr _hostPointer;
         private readonly bool _isOwner;
         private bool _allocatedOnDevice;
@@ -94,6 +95,8 @@ namespace ConvNetSharp.Volume.GPU.Single
 
         public override void CopyFrom(VolumeStorage<float> source)
         {
+            Debug.Assert(!_disposed);
+
             var real = source as VolumeStorage;
 
             if (!object.ReferenceEquals(this, real))
@@ -127,6 +130,8 @@ namespace ConvNetSharp.Volume.GPU.Single
 
         public override void Clear()
         {
+            Debug.Assert(!_disposed);
+
             switch (this.Location)
             {
                 case DataLocation.Host:
@@ -153,6 +158,8 @@ namespace ConvNetSharp.Volume.GPU.Single
 
         public void CopyToDevice()
         {
+            Debug.Assert(!_disposed);
+
             if (this.Location == DataLocation.Host)
             {
                 // Device 
@@ -179,6 +186,8 @@ namespace ConvNetSharp.Volume.GPU.Single
 
         public void CopyToHost()
         {
+            Debug.Assert(!_disposed);
+
             if (this.Location == DataLocation.Device)
             {
                 var res = DriverAPINativeMethods.AsynchronousMemcpy_v2.cuMemcpyDtoHAsync_v2(
@@ -197,6 +206,8 @@ namespace ConvNetSharp.Volume.GPU.Single
 
         public virtual void Dispose(bool disposing)
         {
+            _disposed = true;
+
             if (disposing)
             {
                 GC.SuppressFinalize(this);

--- a/src/ConvNetSharp.Volume.GPU/Single/VolumeStorage.cs
+++ b/src/ConvNetSharp.Volume.GPU/Single/VolumeStorage.cs
@@ -186,9 +186,7 @@ namespace ConvNetSharp.Volume.GPU.Single
                     this.DeviceBuffer.DevicePointer, this.DeviceBuffer.SizeInBytes, this.Context.DefaultStream.Stream);
 
                 if (res != CUResult.Success)
-                {
                     throw new CudaException(res);
-                }
 
                 // Synchro
                 this.Context.DefaultStream.Synchronize();

--- a/src/ConvNetSharp.Volume/Volume.cs
+++ b/src/ConvNetSharp.Volume/Volume.cs
@@ -6,6 +6,7 @@ namespace ConvNetSharp.Volume
 {
     [DebuggerDisplay("Volume {Shape.PrettyPrint()}")]
     public abstract class Volume<T>
+        : IDisposable
         where T : struct, IEquatable<T>, IFormattable
     {
         protected Volume(VolumeStorage<T> storage)
@@ -16,6 +17,13 @@ namespace ConvNetSharp.Volume
         public VolumeStorage<T> Storage { get; }
 
         public Shape Shape => this.Storage.Shape;
+
+        public virtual void Dispose()
+        {
+            var disposable = this.Storage as IDisposable;
+            if (disposable != null)
+                disposable.Dispose();
+        }
 
         public Volume<T> Add(Volume<T> other)
         {
@@ -359,6 +367,6 @@ namespace ConvNetSharp.Volume
             }
 
             return sb.ToString();
-        }
+        }       
     }
 }


### PR DESCRIPTION
This fixes a memory leak when training for a lot of epochs. When reshaping Volume, the reshape constructor first allocated its own memory (using another constructor), and then took over the original VolStorage memory, leaving created one non-freed.