### PR TITLE
Develop

### DIFF
--- a/Examples/Classify2DDemo/Program.cs
+++ b/Examples/Classify2DDemo/Program.cs
@@ -61,7 +61,7 @@ namespace Classify2DDemo
             } while (!Console.KeyAvailable);
 
             // Testing
-            var netx = new Volume(new double[2 * n], new Shape(1, 1, 2, n));
+            var netx = BuilderInstance.Volume.From(new double[2 * n], new Shape(1, 1, 2, n));
             for (var ix = 0; ix < n; ix++)
             {
                 netx.Set(0, 0, 0, ix, data[ix][0]);

--- a/Examples/FlowDemo/ExampleCPUDouble.cs
+++ b/Examples/FlowDemo/ExampleCPUDouble.cs
@@ -78,8 +78,8 @@ namespace FlowDemo
                 double currentCost;
                 do
                 {
-                    var xx = BuilderInstance<double>.Volume.SameAs(new[] { -2.0, -3.0, -10.0 }, new Shape(1, 1, 1, 3));
-                    var yy = BuilderInstance<double>.Volume.SameAs(new[] { -5.0, -6.0, -13.0 }, new Shape(1, 1, 1, 3));
+                    var xx = BuilderInstance<double>.Volume.From(new[] { -2.0, -3.0, -10.0 }, new Shape(1, 1, 1, 3));
+                    var yy = BuilderInstance<double>.Volume.From(new[] { -5.0, -6.0, -13.0 }, new Shape(1, 1, 1, 3));
 
                     var dico = new Dictionary<string, Volume<double>> { { "x", xx }, { "y", yy } };
 

--- a/Examples/FluentMnistDemo/DataSet.cs
+++ b/Examples/FluentMnistDemo/DataSet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using ConvNetSharp.Volume;
 using ConvNetSharp.Volume.Double;
+using Volume = ConvNetSharp.Volume.Volume<double>;
 
 namespace FluentMnistDemo
 {
@@ -41,7 +42,7 @@ namespace FluentMnistDemo
                 }
             }
 
-            var dataVolume = new Volume(data, dataShape);
+            var dataVolume = BuilderInstance.Volume.From(data, dataShape);
 
             for (var i = 0; i < batchSize; i++)
             {
@@ -70,7 +71,7 @@ namespace FluentMnistDemo
             }
 
 
-            var labelVolume = new Volume(label, labelShape);
+            var labelVolume = BuilderInstance.Volume.From(label, labelShape);
 
             return new Tuple<Volume, Volume, int[]>(dataVolume, labelVolume, labels);
         }

--- a/Examples/FluentMnistDemo/Program.cs
+++ b/Examples/FluentMnistDemo/Program.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using ConvNetSharp.Core;
 using ConvNetSharp.Core.Fluent;
 using ConvNetSharp.Core.Training;
-using ConvNetSharp.Volume.Double;
+using Volume = ConvNetSharp.Volume.Volume<double>;
 
 namespace FluentMnistDemo
 {

--- a/Examples/FluentMnistDemo/Properties/AssemblyInfo.cs
+++ b/Examples/FluentMnistDemo/Properties/AssemblyInfo.cs
@@ -26,10 +26,10 @@ using System.Runtime.InteropServices;
 //
 //      Major Version
 //      Minor Version
-//      From Number
+//      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the From and Revision Numbers
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/Examples/FluentMnistDemo/Properties/AssemblyInfo.cs
+++ b/Examples/FluentMnistDemo/Properties/AssemblyInfo.cs
@@ -26,10 +26,10 @@ using System.Runtime.InteropServices;
 //
 //      Major Version
 //      Minor Version
-//      SameAs Number
+//      From Number
 //      Revision
 //
-// You can specify all the values or you can default the SameAs and Revision Numbers
+// You can specify all the values or you can default the From and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/Examples/MinimalExample/Program.cs
+++ b/Examples/MinimalExample/Program.cs
@@ -32,7 +32,7 @@ namespace MinimalExample
             net.AddLayer(new SoftmaxLayer(10));
 
             // forward a random data point through the network
-            var x = new Volume(new[] { 0.3, -0.5 }, new Shape(2));
+            var x =  BuilderInstance.Volume.From(new[] { 0.3, -0.5 }, new Shape(2));
 
             var prob = net.Forward(x);
 
@@ -40,7 +40,7 @@ namespace MinimalExample
             Console.WriteLine("probability that x is class 0: " + prob.Get(0)); // prints e.g. 0.50101
 
             var trainer = new SgdTrainer(net) { LearningRate = 0.01, L2Decay = 0.001 };
-            trainer.Train(x, new Volume(new[] { 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }, new Shape(1, 1, 10, 1))); // train the network, specifying that x is class zero
+            trainer.Train(x, BuilderInstance.Volume.From(new[] { 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }, new Shape(1, 1, 10, 1))); // train the network, specifying that x is class zero
 
             var prob2 = net.Forward(x);
             Console.WriteLine("probability that x is class 0: " + prob2.Get(0));

--- a/Examples/MinimalExample/Properties/AssemblyInfo.cs
+++ b/Examples/MinimalExample/Properties/AssemblyInfo.cs
@@ -26,10 +26,10 @@ using System.Runtime.InteropServices;
 //
 //      Major Version
 //      Minor Version
-//      From Number
+//      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the From and Revision Numbers
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/Examples/MinimalExample/Properties/AssemblyInfo.cs
+++ b/Examples/MinimalExample/Properties/AssemblyInfo.cs
@@ -26,10 +26,10 @@ using System.Runtime.InteropServices;
 //
 //      Major Version
 //      Minor Version
-//      SameAs Number
+//      From Number
 //      Revision
 //
-// You can specify all the values or you can default the SameAs and Revision Numbers
+// You can specify all the values or you can default the From and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/Examples/MnistDemo.Flow.GPU/DataSet.cs
+++ b/Examples/MnistDemo.Flow.GPU/DataSet.cs
@@ -17,7 +17,7 @@ namespace MnistDemo.GPU
             this._trainImages = trainImages;
         }
 
-        public Tuple<Volume, Volume, int[]> NextBatch(int batchSize)
+        public Tuple<Volume<float>, Volume<float>, int[]> NextBatch(int batchSize)
         {
             const int w = 28;
             const int h = 28;
@@ -41,7 +41,7 @@ namespace MnistDemo.GPU
                 }
             }
 
-            var dataVolume = new Volume(data, dataShape);
+            var dataVolume = BuilderInstance.Volume.From(data, dataShape);
 
             for (var i = 0; i < batchSize; i++)
             {
@@ -70,9 +70,9 @@ namespace MnistDemo.GPU
             }
 
 
-            var labelVolume = new Volume(label, labelShape);
+            var labelVolume = BuilderInstance.Volume.From(label, labelShape);
 
-            return new Tuple<Volume, Volume, int[]>(dataVolume, labelVolume, labels);
+            return new Tuple<Volume<float>, Volume<float>, int[]>(dataVolume, labelVolume, labels);
         }
     }
 }

--- a/Examples/MnistDemo.Flow.GPU/Program.cs
+++ b/Examples/MnistDemo.Flow.GPU/Program.cs
@@ -7,7 +7,8 @@ using ConvNetSharp.Flow.Fluent;
 using ConvNetSharp.Flow.Layers;
 using ConvNetSharp.Flow.Training;
 using ConvNetSharp.Utils.GraphVisualizer;
-using ConvNetSharp.Volume.GPU.Single;
+using ConvNetSharp.Volume;
+
 
 namespace MnistDemo.GPU
 {
@@ -28,7 +29,7 @@ namespace MnistDemo.GPU
 
         private void MnistDemo()
         {
-                        BuilderInstance.Volume = new VolumeBuilder();
+            BuilderInstance<float>.Volume = new ConvNetSharp.Volume.GPU.Single.VolumeBuilder();
 
             var datasets = new DataSets();
             if (!datasets.Load(100))
@@ -104,7 +105,7 @@ namespace MnistDemo.GPU
             this._trainer.Dispose();
         }
 
-        private void Test(Volume x, int[] labels, CircularBuffer<double> accuracy, bool forward = true)
+        private void Test(Volume<float> x, int[] labels, CircularBuffer<double> accuracy, bool forward = true)
         {
             if (forward)
             {
@@ -121,7 +122,7 @@ namespace MnistDemo.GPU
             x.Dispose();
         }
 
-        private void Train(Volume x, Volume y, int[] labels)
+        private void Train(Volume<float> x, Volume<float> y, int[] labels)
         {
             this._trainer.Train(x, y);
 

--- a/Examples/MnistDemo.Flow.GPU/Properties/AssemblyInfo.cs
+++ b/Examples/MnistDemo.Flow.GPU/Properties/AssemblyInfo.cs
@@ -26,10 +26,10 @@ using System.Runtime.InteropServices;
 //
 //      Major Version
 //      Minor Version
-//      From Number
+//      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the From and Revision Numbers
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/Examples/MnistDemo.Flow.GPU/Properties/AssemblyInfo.cs
+++ b/Examples/MnistDemo.Flow.GPU/Properties/AssemblyInfo.cs
@@ -26,10 +26,10 @@ using System.Runtime.InteropServices;
 //
 //      Major Version
 //      Minor Version
-//      SameAs Number
+//      From Number
 //      Revision
 //
-// You can specify all the values or you can default the SameAs and Revision Numbers
+// You can specify all the values or you can default the From and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/Examples/MnistDemo.GPU/DataSet.cs
+++ b/Examples/MnistDemo.GPU/DataSet.cs
@@ -17,7 +17,7 @@ namespace MnistDemo.GPU
             this._trainImages = trainImages;
         }
 
-        public Tuple<Volume, Volume, int[]> NextBatch(int batchSize)
+        public Tuple<Volume<float>, Volume<float>, int[]> NextBatch(int batchSize)
         {
             const int w = 28;
             const int h = 28;
@@ -41,7 +41,7 @@ namespace MnistDemo.GPU
                 }
             }
 
-            var dataVolume = new Volume(data, dataShape);
+            var dataVolume = BuilderInstance.Volume.From(data, dataShape);
 
             for (var i = 0; i < batchSize; i++)
             {
@@ -70,9 +70,9 @@ namespace MnistDemo.GPU
             }
 
 
-            var labelVolume = new Volume(label, labelShape);
+            var labelVolume = BuilderInstance.Volume.From(label, labelShape);
 
-            return new Tuple<Volume, Volume, int[]>(dataVolume, labelVolume, labels);
+            return new Tuple<Volume<float>, Volume<float>, int[]>(dataVolume, labelVolume, labels);
         }
     }
 }

--- a/Examples/MnistDemo.GPU/Program.cs
+++ b/Examples/MnistDemo.GPU/Program.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using ConvNetSharp.Core;
 using ConvNetSharp.Core.Layers.Single;
 using ConvNetSharp.Core.Training.Single;
+using ConvNetSharp.Volume;
 using ConvNetSharp.Volume.GPU.Single;
 
 namespace MnistDemo.GPU
@@ -37,7 +38,7 @@ namespace MnistDemo.GPU
             this._net = new Net<float>();
             this._net.AddLayer(new InputLayer(28, 28, 1));
             this.convLayer = new ConvLayer(5, 5, 8) { Stride = 1, Pad = 2 };
-            this._net.AddLayer(convLayer);
+            this._net.AddLayer(this.convLayer);
             this._net.AddLayer(new ReluLayer());
             this._net.AddLayer(new PoolLayer(2, 2) { Stride = 2 });
             this._net.AddLayer(new ConvLayer(5, 5, 16) { Stride = 1, Pad = 2 });
@@ -61,7 +62,7 @@ namespace MnistDemo.GPU
             this._trainer = new SgdTrainer(this._net)
             {
                 LearningRate = 0.01f,
-                BatchSize = 1024,
+                BatchSize = 1024
                 //L2Decay = 0.001f,
                 //Momentum = 0.9f
             };
@@ -89,12 +90,15 @@ namespace MnistDemo.GPU
                     Math.Round(this._trainer.BackwardTimeMs, 2),
                     Math.Round(this._trainer.UpdateWeightsTimeMs, 2));
 
-                File.AppendAllLines("loss.csv", new[] { $"{this._stepCount}, {this._trainer.Loss}, { Math.Round(this._trainAccWindow.Items.Average() * 100.0, 2)}, {Math.Round(this._testAccWindow.Items.Average() * 100.0, 2)}" });
-
+                File.AppendAllLines("loss.csv",
+                    new[]
+                    {
+                        $"{this._stepCount}, {this._trainer.Loss}, {Math.Round(this._trainAccWindow.Items.Average() * 100.0, 2)}, {Math.Round(this._testAccWindow.Items.Average() * 100.0, 2)}"
+                    });
             } while (!Console.KeyAvailable);
         }
 
-        private void Test(Volume x, int[] labels, CircularBuffer<double> accuracy, bool forward = true)
+        private void Test(Volume<float> x, int[] labels, CircularBuffer<double> accuracy, bool forward = true)
         {
             if (forward)
             {
@@ -111,7 +115,7 @@ namespace MnistDemo.GPU
             x.Dispose();
         }
 
-        private void Train(Volume x, Volume y, int[] labels)
+        private void Train(Volume<float> x, Volume<float> y, int[] labels)
         {
             this._trainer.Train(x, y);
 

--- a/Examples/MnistDemo/DataSet.cs
+++ b/Examples/MnistDemo/DataSet.cs
@@ -17,7 +17,7 @@ namespace MnistDemo
             this._trainImages = trainImages;
         }
 
-        public Tuple<Volume, Volume, int[]> NextBatch(int batchSize)
+        public Tuple<Volume<double>, Volume<double>, int[]> NextBatch(int batchSize)
         {
             const int w = 28;
             const int h = 28;
@@ -41,7 +41,7 @@ namespace MnistDemo
                 }
             }
 
-            var dataVolume = new Volume(data, dataShape);
+            var dataVolume = BuilderInstance.Volume.From(data, dataShape);
 
             for (var i = 0; i < batchSize; i++)
             {
@@ -70,9 +70,9 @@ namespace MnistDemo
             }
 
 
-            var labelVolume = new Volume(label, labelShape);
+            var labelVolume = BuilderInstance.Volume.From(label, labelShape);
 
-            return new Tuple<Volume, Volume, int[]>(dataVolume, labelVolume, labels);
+            return new Tuple<Volume<double>, Volume<double>, int[]>(dataVolume, labelVolume, labels);
         }
     }
 }

--- a/Examples/MnistDemo/Program.cs
+++ b/Examples/MnistDemo/Program.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using ConvNetSharp.Core;
 using ConvNetSharp.Core.Layers.Double;
 using ConvNetSharp.Core.Training;
-using ConvNetSharp.Volume.Double;
+using ConvNetSharp.Volume;
 
 namespace MnistDemo
 {
@@ -68,7 +68,7 @@ namespace MnistDemo
             } while (!Console.KeyAvailable);
         }
 
-        private void Test(Volume x, int[] labels, CircularBuffer<double> accuracy, bool forward = true)
+        private void Test(Volume<double> x, int[] labels, CircularBuffer<double> accuracy, bool forward = true)
         {
             if (forward)
             {
@@ -83,7 +83,7 @@ namespace MnistDemo
             }
         }
 
-        private void Train(Volume x, Volume y, int[] labels)
+        private void Train(Volume<double> x, Volume<double> y, int[] labels)
         {
             this._trainer.Train(x, y);
 

--- a/src/ConvNetSharp.Core.Tests/ConvLayerTests.cs
+++ b/src/ConvNetSharp.Core.Tests/ConvLayerTests.cs
@@ -28,7 +28,7 @@ namespace ConvNetSharp.Core.Tests
             var output = layer.DoForward(input, true);
 
             // Set output gradients to 1
-            var outputGradient = BuilderInstance<double>.Volume.SameAs(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
+            var outputGradient = BuilderInstance<double>.Volume.From(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
 
             // Backward pass to retrieve gradients
             layer.Backward(outputGradient);

--- a/src/ConvNetSharp.Core.Tests/ConvNetSharp.Core.Tests.csproj
+++ b/src/ConvNetSharp.Core.Tests/ConvNetSharp.Core.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="PoolLayerTests.cs" />
     <Compile Include="LeakyReluLayerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RegressionLayerTests.cs" />
     <Compile Include="ReluLayerTests.cs" />
     <Compile Include="SerializationTests.cs" />
     <Compile Include="SigmoidLayerTests.cs" />

--- a/src/ConvNetSharp.Core.Tests/FullyConnLayerTests.cs
+++ b/src/ConvNetSharp.Core.Tests/FullyConnLayerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using ConvNetSharp.Core.Layers;
 using ConvNetSharp.Volume;
+using ConvNetSharp.Volume.Double;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ConvNetSharp.Core.Tests
@@ -24,7 +25,7 @@ namespace ConvNetSharp.Core.Tests
             var output = layer.DoForward(input, true);
 
             // Set output gradients to 1
-            var outputGradient = BuilderInstance<double>.Volume.SameAs(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
+            var outputGradient = BuilderInstance<double>.Volume.From(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
 
             // Backward pass to retrieve gradients
             layer.Backward(outputGradient);
@@ -59,7 +60,7 @@ namespace ConvNetSharp.Core.Tests
                 layer.Filters.Set(0, 0, i, 1, i * 2.0);
             }
 
-            var input = new Volume.Double.Volume(new[]
+            var input = BuilderInstance.Volume.From(new[]
             {
                 1.0, 2.0,
                 3.0, 4.0,

--- a/src/ConvNetSharp.Core.Tests/GradientCheckTools.cs
+++ b/src/ConvNetSharp.Core.Tests/GradientCheckTools.cs
@@ -18,7 +18,7 @@ namespace ConvNetSharp.Core.Tests
             var output = layer.DoForward(input, true);
 
             // Set output gradients to 1
-            var outputGradient = BuilderInstance<double>.Volume.SameAs(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
+            var outputGradient = BuilderInstance<double>.Volume.From(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
 
             // Backward pass to retrieve gradients
             layer.Backward(outputGradient);
@@ -61,11 +61,11 @@ namespace ConvNetSharp.Core.Tests
             layer.Init(inputWidth, inputHeight, inputDepth);
 
             // Forward pass
-            var input = BuilderInstance<double>.Volume.SameAs(new double[inputWidth * inputHeight * inputDepth * bacthSize].Populate(1.0), new Shape(inputWidth, inputHeight, inputDepth, bacthSize));
+            var input = BuilderInstance<double>.Volume.From(new double[inputWidth * inputHeight * inputDepth * bacthSize].Populate(1.0), new Shape(inputWidth, inputHeight, inputDepth, bacthSize));
             var output = layer.DoForward(input);
 
             // Set output gradients to 1
-            var outputGradient = BuilderInstance<double>.Volume.SameAs(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
+            var outputGradient = BuilderInstance<double>.Volume.From(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
 
             // Backward pass to retrieve gradients
             layer.Backward(outputGradient);
@@ -80,7 +80,7 @@ namespace ConvNetSharp.Core.Tests
                 // Now let's approximate gradient
                 for (var i = 0; i < paramAndGrad.Volume.Shape.TotalLength; i++)
                 {
-                    input = BuilderInstance<double>.Volume.SameAs(new double[input.Shape.TotalLength].Populate(1.0), input.Shape);
+                    input = BuilderInstance<double>.Volume.From(new double[input.Shape.TotalLength].Populate(1.0), input.Shape);
 
                     var oldValue = vol.Get(i);
                     vol.Set(i, oldValue + epsilon);

--- a/src/ConvNetSharp.Core.Tests/LeakyReluLayerTests.cs
+++ b/src/ConvNetSharp.Core.Tests/LeakyReluLayerTests.cs
@@ -24,7 +24,7 @@ namespace ConvNetSharp.Core.Tests
             var output = layer.DoForward(input, true);
 
             // Set output gradients to 1
-            var outputGradient = BuilderInstance.Volume.SameAs(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
+            var outputGradient = BuilderInstance.Volume.From(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
 
             // Backward pass to retrieve gradients
             layer.Backward(outputGradient);

--- a/src/ConvNetSharp.Core.Tests/PoolLayerTests.cs
+++ b/src/ConvNetSharp.Core.Tests/PoolLayerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using ConvNetSharp.Core.Layers;
 using ConvNetSharp.Volume;
+using ConvNetSharp.Volume.Double;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ConvNetSharp.Core.Tests
@@ -25,7 +26,7 @@ namespace ConvNetSharp.Core.Tests
             {
                 data[i] = i;
             }
-            var input = new Volume.Double.Volume(data, new Shape(inputWidth, inputHeight, inputDepth, inputBatchSize));
+            var input = BuilderInstance.Volume.From(data, new Shape(inputWidth, inputHeight, inputDepth, inputBatchSize));
             layer.DoForward(input);
 
             Assert.AreEqual(2, layer.OutputActivation.Shape.GetDimension(0));
@@ -75,7 +76,7 @@ namespace ConvNetSharp.Core.Tests
             var output = layer.DoForward(input, true);
 
             // Set output gradients to 1
-            var outputGradient = BuilderInstance<double>.Volume.SameAs(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
+            var outputGradient = BuilderInstance<double>.Volume.From(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
 
             // Backward pass to retrieve gradients
             layer.Backward(outputGradient);

--- a/src/ConvNetSharp.Core.Tests/RegressionLayerTests.cs
+++ b/src/ConvNetSharp.Core.Tests/RegressionLayerTests.cs
@@ -1,0 +1,24 @@
+﻿using ConvNetSharp.Core.Layers.Double;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ConvNetSharp.Core.Tests
+{
+    [TestClass]
+    public class RegressionLayerTests
+    {
+        [TestMethod]
+        public void Instantiation()
+        {
+            const int inputWidth = 20;
+            const int inputHeight = 20;
+            const int inputDepth = 2;
+
+            var layer = new ReluLayer();
+            layer.Init(inputWidth, inputHeight, inputDepth);
+
+            Assert.AreEqual(20, layer.OutputWidth);
+            Assert.AreEqual(20, layer.OutputHeight);
+            Assert.AreEqual(2, layer.OutputDepth);
+        }
+    }
+}

--- a/src/ConvNetSharp.Core.Tests/ReluLayerTests.cs
+++ b/src/ConvNetSharp.Core.Tests/ReluLayerTests.cs
@@ -24,7 +24,7 @@ namespace ConvNetSharp.Core.Tests
             var output = layer.DoForward(input, true);
 
             // Set output gradients to 1
-            var outputGradient = BuilderInstance.Volume.SameAs(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
+            var outputGradient = BuilderInstance.Volume.From(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
 
             // Backward pass to retrieve gradients
             layer.Backward(outputGradient);

--- a/src/ConvNetSharp.Core.Tests/SigmoidLayerTests.cs
+++ b/src/ConvNetSharp.Core.Tests/SigmoidLayerTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using ConvNetSharp.Core.Layers;
 using ConvNetSharp.Volume;
+using ConvNetSharp.Volume.Double;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ConvNetSharp.Core.Tests
@@ -20,7 +21,7 @@ namespace ConvNetSharp.Core.Tests
             var layer = new SigmoidLayer<double>();
             layer.Init(inputWidth, inputHeight, inputDepth);
 
-            var input = new Volume.Double.Volume(new[]
+            var input = BuilderInstance.Volume.From(new[]
             {
                 1.0, 2.0,
                 3.0, 4.0,
@@ -79,7 +80,7 @@ namespace ConvNetSharp.Core.Tests
             var output = layer.DoForward(input, true);
 
             // Set output gradients to 1
-            var outputGradient = BuilderInstance<double>.Volume.SameAs(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
+            var outputGradient = BuilderInstance<double>.Volume.From(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
 
             // Backward pass to retrieve gradients
             layer.Backward(outputGradient);

--- a/src/ConvNetSharp.Core.Tests/SoftMaxLayerTests.cs
+++ b/src/ConvNetSharp.Core.Tests/SoftMaxLayerTests.cs
@@ -18,7 +18,7 @@ namespace ConvNetSharp.Core.Tests
             this.layer = new SoftmaxLayer(4);
             this.layer.Init(1, 1, 4);
 
-            this.input = Volume.SameAs(new[]
+            this.input = Volume.From(new[]
             {
                 0.1, 0.1, 0.1, 0.1,
                 1000, 2000, 3000, 4000,

--- a/src/ConvNetSharp.Core.Tests/TanhLayerTests.cs
+++ b/src/ConvNetSharp.Core.Tests/TanhLayerTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using ConvNetSharp.Core.Layers;
 using ConvNetSharp.Volume;
+using ConvNetSharp.Volume.Double;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ConvNetSharp.Core.Tests
@@ -20,7 +21,7 @@ namespace ConvNetSharp.Core.Tests
             var layer = new TanhLayer<double>();
             layer.Init(inputWidth, inputHeight, inputDepth);
 
-            var input = new Volume.Double.Volume(new[]
+            var input = BuilderInstance.Volume.From(new[]
             {
                 1.0, 2.0,
                 3.0, 4.0,
@@ -78,7 +79,7 @@ namespace ConvNetSharp.Core.Tests
             var output = layer.DoForward(input, true);
 
             // Set output gradients to 1
-            var outputGradient = BuilderInstance<double>.Volume.SameAs(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
+            var outputGradient = BuilderInstance<double>.Volume.From(new double[output.Shape.TotalLength].Populate(1.0), output.Shape);
 
             // Backward pass to retrieve gradients
             layer.Backward(outputGradient);

--- a/src/ConvNetSharp.Core/Layers/ConvLayer.cs
+++ b/src/ConvNetSharp.Core/Layers/ConvLayer.cs
@@ -21,11 +21,11 @@ namespace ConvNetSharp.Core.Layers
             this.Height = Convert.ToInt32(data["Height"]);
             this.Stride = Convert.ToInt32(data["Stride"]);
             this.Pad = Convert.ToInt32(data["Pad"]);
-            this.Filters = BuilderInstance<T>.Volume.SameAs(data["Filters"].ToArrayOfT<T>(), new Shape(this.Width, this.Height, this.InputDepth, this.FilterCount));
-            this.Bias = BuilderInstance<T>.Volume.SameAs(data["Bias"].ToArrayOfT<T>(), new Shape(1, 1, this.FilterCount));
+            this.Filters = BuilderInstance<T>.Volume.From(data["Filters"].ToArrayOfT<T>(), new Shape(this.Width, this.Height, this.InputDepth, this.FilterCount));
+            this.Bias = BuilderInstance<T>.Volume.From(data["Bias"].ToArrayOfT<T>(), new Shape(1, 1, this.FilterCount));
             this.BiasPref = (T) Convert.ChangeType(data["BiasPref"], typeof(T));
-            this.FiltersGradient = BuilderInstance<T>.Volume.SameAs(data["FiltersGradient"].ToArrayOfT<T>(), new Shape(this.Width, this.Height, this.InputDepth, this.FilterCount));
-            this.BiasGradient = BuilderInstance<T>.Volume.SameAs(data["BiasGradient"].ToArrayOfT<T>(), new Shape(1, 1, this.FilterCount));
+            this.FiltersGradient = BuilderInstance<T>.Volume.From(data["FiltersGradient"].ToArrayOfT<T>(), new Shape(this.Width, this.Height, this.InputDepth, this.FilterCount));
+            this.BiasGradient = BuilderInstance<T>.Volume.From(data["BiasGradient"].ToArrayOfT<T>(), new Shape(1, 1, this.FilterCount));
 
             this.IsInitialized = true;
         }
@@ -188,7 +188,7 @@ namespace ConvNetSharp.Core.Layers
                 this.FiltersGradient = BuilderInstance<T>.Volume.SameAs(shape);
             }
 
-            this.Bias = BuilderInstance<T>.Volume.SameAs(new T[this.OutputDepth].Populate(this.BiasPref),
+            this.Bias = BuilderInstance<T>.Volume.From(new T[this.OutputDepth].Populate(this.BiasPref),
                 new Shape(1, 1, this.OutputDepth));
             this.BiasGradient = BuilderInstance<T>.Volume.SameAs(new Shape(1, 1, this.OutputDepth));
         }

--- a/src/ConvNetSharp.Core/Layers/FullyConnLayer.cs
+++ b/src/ConvNetSharp.Core/Layers/FullyConnLayer.cs
@@ -15,11 +15,11 @@ namespace ConvNetSharp.Core.Layers
             this.L2DecayMul = Ops<T>.One;
 
             this.NeuronCount = Convert.ToInt32(data["NeuronCount"]);
-            this.Filters = BuilderInstance<T>.Volume.SameAs(data["Filters"].ToArrayOfT<T>(), new Shape(1, 1, this.InputWidth * this.InputHeight * this.InputDepth, this.NeuronCount));
-            this.Bias = BuilderInstance<T>.Volume.SameAs(data["Bias"].ToArrayOfT<T>(), new Shape(1, 1, this.NeuronCount));
+            this.Filters = BuilderInstance<T>.Volume.From(data["Filters"].ToArrayOfT<T>(), new Shape(1, 1, this.InputWidth * this.InputHeight * this.InputDepth, this.NeuronCount));
+            this.Bias = BuilderInstance<T>.Volume.From(data["Bias"].ToArrayOfT<T>(), new Shape(1, 1, this.NeuronCount));
             this.BiasPref = (T)Convert.ChangeType(data["BiasPref"], typeof(T));
-            this.BiasGradient = BuilderInstance<T>.Volume.SameAs(data["BiasGradient"].ToArrayOfT<T>(), new Shape(1, 1, this.NeuronCount));
-            this.FiltersGradient = BuilderInstance<T>.Volume.SameAs(data["FiltersGradient"].ToArrayOfT<T>(), new Shape(1, 1, this.InputWidth * this.InputHeight * this.InputDepth, this.NeuronCount));
+            this.BiasGradient = BuilderInstance<T>.Volume.From(data["BiasGradient"].ToArrayOfT<T>(), new Shape(1, 1, this.NeuronCount));
+            this.FiltersGradient = BuilderInstance<T>.Volume.From(data["FiltersGradient"].ToArrayOfT<T>(), new Shape(1, 1, this.InputWidth * this.InputHeight * this.InputDepth, this.NeuronCount));
             this.IsInitialized = true;
         }
 
@@ -142,7 +142,7 @@ namespace ConvNetSharp.Core.Layers
             var scale = Math.Sqrt(2.0 / inputCount);
             this.Filters = BuilderInstance<T>.Volume.Random(new Shape(1, 1, inputCount, this.NeuronCount), 0, scale);
             this.FiltersGradient = BuilderInstance<T>.Volume.SameAs(new Shape(1, 1, inputCount, this.NeuronCount));
-            this.Bias = BuilderInstance<T>.Volume.SameAs(new T[this.NeuronCount].Populate(this.BiasPref), new Shape(1, 1, this.NeuronCount));
+            this.Bias = BuilderInstance<T>.Volume.From(new T[this.NeuronCount].Populate(this.BiasPref), new Shape(1, 1, this.NeuronCount));
             this.BiasGradient = BuilderInstance<T>.Volume.SameAs(new Shape(1, 1, this.NeuronCount));
         }
     }

--- a/src/ConvNetSharp.Core/Layers/RegressionLayer.cs
+++ b/src/ConvNetSharp.Core/Layers/RegressionLayer.cs
@@ -23,6 +23,15 @@ namespace ConvNetSharp.Core.Layers
         {
         }
 
+        public override void Init(int inputWidth, int inputHeight, int inputDepth)
+        {
+            base.Init(inputWidth, inputHeight, inputDepth);
+
+            this.OutputWidth = inputWidth;
+            this.OutputHeight = inputHeight;
+            this.OutputDepth = inputDepth;
+        }
+
         public override void Backward(Volume<T> outputGradient)
         {
             throw new NotImplementedException();

--- a/src/ConvNetSharp.Flow.Tests/DoubleOpTests.cs
+++ b/src/ConvNetSharp.Flow.Tests/DoubleOpTests.cs
@@ -16,7 +16,7 @@ namespace ConvNetSharp.Flow.Tests
 
         protected override Volume<double> NewVolume(double[] values, Shape shape)
         {
-            return new Volume.Double.Volume(values, shape);
+            return BuilderInstance.Volume.From(values, shape);
         }
     }
 }

--- a/src/ConvNetSharp.Flow.Tests/OpTests.cs
+++ b/src/ConvNetSharp.Flow.Tests/OpTests.cs
@@ -76,10 +76,10 @@ namespace ConvNetSharp.Flow.Tests
 
             // Same weights
             var convfilterCore1 = netFlow.Session.GetVariableByName(netFlow.Op, (convLayerFlow1.Filter as IPersistable<T>).Name);
-            convfilterCore1.Result = BuilderInstance<T>.Volume.SameAs(convLayerCore1.Filters.ToArray(), convLayerCore1.Filters.Shape);
+            convfilterCore1.Result = BuilderInstance<T>.Volume.From(convLayerCore1.Filters.ToArray(), convLayerCore1.Filters.Shape);
 
             var fullyfilterCore = netFlow.Session.GetVariableByName(netFlow.Op, (fullyConnLayerFlow.Filter as IPersistable<T>).Name);
-            fullyfilterCore.Result = BuilderInstance<T>.Volume.SameAs(fullyConnLayerCore.Filters.ToArray(), fullyConnLayerCore.Filters.Shape);
+            fullyfilterCore.Result = BuilderInstance<T>.Volume.From(fullyConnLayerCore.Filters.ToArray(), fullyConnLayerCore.Filters.Shape);
 
             // Create input
             var xStorage = new double[inputWidth * inputHeigth * inputDepth * batchSize].Populate(1.0);

--- a/src/ConvNetSharp.Flow.Tests/OpsTests.cs
+++ b/src/ConvNetSharp.Flow.Tests/OpsTests.cs
@@ -84,7 +84,7 @@ namespace ConvNetSharp.Flow.Tests
         public void AddOpBackward()
         {
             var volA = new Const<double>(BuilderInstance<double>.Volume.SameAs(new Shape(1, 1, 3, 5)), "A");
-            var volB = new Const<double>(BuilderInstance<double>.Volume.SameAs(new[] { 1.0, 2.0, 3.0 }, new Shape(1, 1, 3, 1)), "bias");
+            var volB = new Const<double>(BuilderInstance<double>.Volume.From(new[] { 1.0, 2.0, 3.0 }, new Shape(1, 1, 3, 1)), "bias");
             var op = new Add<double>(volA, volB);
 
             using (var session = new Session<double>())
@@ -92,7 +92,7 @@ namespace ConvNetSharp.Flow.Tests
                 var eval = op.Evaluate(session);
                 Assert.IsNotNull(eval);
 
-                op.Derivate = new Const<double>(BuilderInstance<double>.Volume.SameAs(new double[15].Populate(1.0), new Shape(1, 1, 3, 5)), "error");
+                op.Derivate = new Const<double>(BuilderInstance<double>.Volume.From(new double[15].Populate(1.0), new Shape(1, 1, 3, 5)), "error");
 
                 op.Differentiate();
 
@@ -177,7 +177,7 @@ namespace ConvNetSharp.Flow.Tests
         [TestMethod]
         public void SumOp()
         {
-            var x = new Const<float>(BuilderInstance<float>.Volume.SameAs(new[] { 1.0f, 2.0f, 3.0f }, new Shape(3)), "x");
+            var x = new Const<float>(BuilderInstance<float>.Volume.From(new[] { 1.0f, 2.0f, 3.0f }, new Shape(3)), "x");
             var op = new Sum<float>(x, new Shape(1));
 
             using (var session = new Session<float>())
@@ -190,7 +190,7 @@ namespace ConvNetSharp.Flow.Tests
         [TestMethod]
         public void SumOpDerivative()
         {
-            var x = new Const<float>(BuilderInstance<float>.Volume.SameAs(new float[] { 1.0f, 2.0f, 3.0f }, new Shape(3)), "x");
+            var x = new Const<float>(BuilderInstance<float>.Volume.From(new float[] { 1.0f, 2.0f, 3.0f }, new Shape(3)), "x");
             var op = new Sum<float>(x, new Shape(1));
 
             using (var session = new Session<float>())

--- a/src/ConvNetSharp.Flow.Tests/SingleGpuOpTests.cs
+++ b/src/ConvNetSharp.Flow.Tests/SingleGpuOpTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using ConvNetSharp.Flow.Ops;
 using ConvNetSharp.Volume;
+using ConvNetSharp.Volume.GPU.Single;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ConvNetSharp.Flow.Tests
@@ -11,13 +12,13 @@ namespace ConvNetSharp.Flow.Tests
         public SingleGpuOpTests()
         {
             Op<float>.Count = 1;
-            BuilderInstance<float>.Volume = new Volume.GPU.Single.VolumeBuilder();
+            BuilderInstance<float>.Volume = new VolumeBuilder();
         }
 
         protected override Volume<float> NewVolume(double[] values, Shape shape)
         {
-            var converted = values.Select(i => (float)i).ToArray();
-            return new Volume.GPU.Single.Volume(converted, shape);
+            var converted = values.Select(i => (float) i).ToArray();
+            return BuilderInstance.Volume.From(converted, shape);
         }
     }
 }

--- a/src/ConvNetSharp.Flow.Tests/SingleOpTests.cs
+++ b/src/ConvNetSharp.Flow.Tests/SingleOpTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using ConvNetSharp.Flow.Ops;
 using ConvNetSharp.Volume;
+using ConvNetSharp.Volume.Single;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ConvNetSharp.Flow.Tests
@@ -17,7 +18,7 @@ namespace ConvNetSharp.Flow.Tests
         protected override Volume<float> NewVolume(double[] values, Shape shape)
         {
             var converted = values.Select(i => (float)i).ToArray();
-            return new Volume.Single.Volume(converted, shape);
+            return BuilderInstance.Volume.From(converted, shape);
         }
     }
 }

--- a/src/ConvNetSharp.Flow/Layers/ConvLayer.cs
+++ b/src/ConvNetSharp.Flow/Layers/ConvLayer.cs
@@ -74,7 +74,7 @@ namespace ConvNetSharp.Flow.Layers
             using (ConvNetSharp<T>.Instance.Scope($"ConvLayer_{this.Id}"))
             {
                 var content = new T[this._filterCount].Populate(this.BiasPref);
-                this._bias = cns.Variable(BuilderInstance<T>.Volume.SameAs(content, new Shape(1, 1, this._filterCount, 1)), "Bias");
+                this._bias = cns.Variable(BuilderInstance<T>.Volume.From(content, new Shape(1, 1, this._filterCount, 1)), "Bias");
                 this._conv = cns.Conv(parent.Op, this._width, this._height, this._filterCount, this.Stride, this.Pad);
                 this.Op = this._conv + this._bias;
             }

--- a/src/ConvNetSharp.Flow/Serialization/SerializationExtensions.cs
+++ b/src/ConvNetSharp.Flow/Serialization/SerializationExtensions.cs
@@ -149,7 +149,7 @@ namespace ConvNetSharp.Flow.Serialization
             var shape = new Shape(dim0, dim1, dim2, dim3);
             var data = dico["vol"].ToArrayOfT<T>();
 
-            return BuilderInstance<T>.Volume.SameAs(data, shape);
+            return BuilderInstance<T>.Volume.From(data, shape);
         }
 
         public static List<Op<T>> Load<T>(string name, bool includeCost) where T : struct, IEquatable<T>, IFormattable

--- a/src/ConvNetSharp.Volume.GPU.Tests/SingleVolumeTests.cs
+++ b/src/ConvNetSharp.Volume.GPU.Tests/SingleVolumeTests.cs
@@ -15,7 +15,7 @@ namespace ConvNetSharp.Volume.GPU.Tests
         protected override Volume<float> NewVolume(double[] values, Shape shape)
         {
             var converted = values.Select(i => (float)i).ToArray();
-            return new Single.Volume(converted, shape);
+            return BuilderInstance.Volume.From(converted, shape);
         }
     }
 }

--- a/src/ConvNetSharp.Volume.GPU/Double/VolumeBuilder.cs
+++ b/src/ConvNetSharp.Volume.GPU/Double/VolumeBuilder.cs
@@ -44,7 +44,7 @@ namespace ConvNetSharp.Volume.GPU.Double
             throw new NotImplementedException();
         }
 
-        public override Volume<double> SameAs(double[] value, Shape shape)
+        public override Volume<double> From(double[] value, Shape shape)
         {
             return new Volume(new VolumeStorage(value, shape, this.Context));
         }

--- a/src/ConvNetSharp.Volume.GPU/Single/Volume.cs
+++ b/src/ConvNetSharp.Volume.GPU/Single/Volume.cs
@@ -13,7 +13,7 @@ namespace ConvNetSharp.Volume.GPU.Single
         private readonly GpuContext _context;
         private readonly VolumeStorage _volumeStorage;
 
-        public Volume(VolumeStorage storage) : base(storage)
+        internal Volume(VolumeStorage storage) : base(storage)
         {
             this._context = storage.Context;
             this._volumeStorage = this.Storage as VolumeStorage;
@@ -21,7 +21,7 @@ namespace ConvNetSharp.Volume.GPU.Single
             LoadKernels();
         }
 
-        public Volume(float[] array, Shape shape) : base(new VolumeStorage(array, shape, GpuContext.Default))
+        internal Volume(float[] array, Shape shape) : base(new VolumeStorage(array, shape, GpuContext.Default))
         {
             this._context = GpuContext.Default;
             this._volumeStorage = this.Storage as VolumeStorage;

--- a/src/ConvNetSharp.Volume.GPU/Single/VolumeBuilder.cs
+++ b/src/ConvNetSharp.Volume.GPU/Single/VolumeBuilder.cs
@@ -44,7 +44,7 @@ namespace ConvNetSharp.Volume.GPU.Single
             throw new NotImplementedException();
         }
 
-        public override Volume<float> SameAs(float[] value, Shape shape)
+        public override Volume<float> From(float[] value, Shape shape)
         {
             return new Volume(new VolumeStorage(value, shape, this.Context));
         }

--- a/src/ConvNetSharp.Volume.Tests/DoubleVolumeTests.cs
+++ b/src/ConvNetSharp.Volume.Tests/DoubleVolumeTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using ConvNetSharp.Volume.Double;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ConvNetSharp.Volume.Tests
 {
@@ -7,7 +8,7 @@ namespace ConvNetSharp.Volume.Tests
     {
         protected override Volume<double> NewVolume(double[] values, Shape shape)
         {
-            return new Double.Volume(values, shape);
+            return BuilderInstance.Volume.From(values, shape);
         }
     }
 }

--- a/src/ConvNetSharp.Volume.Tests/GenericVolumeTests.cs
+++ b/src/ConvNetSharp.Volume.Tests/GenericVolumeTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using ConvNetSharp.Volume.Double;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ConvNetSharp.Volume.Tests
@@ -20,7 +21,7 @@ namespace ConvNetSharp.Volume.Tests
         [TestMethod]
         public void ReShape_UnknownDimension()
         {
-            var volume = new Double.Volume(new[] { 1.0, 2.0, 3.0 }, new Shape(3));
+            var volume = BuilderInstance.Volume.From(new[] { 1.0, 2.0, 3.0 }, new Shape(3));
 
             var reshaped = volume.ReShape(1, -1);
             Assert.AreEqual(reshaped.Shape.DimensionCount, 2);
@@ -31,14 +32,14 @@ namespace ConvNetSharp.Volume.Tests
         [ExpectedException(typeof(ArgumentException), "Imcompatible dimensions provided")]
         public void ReShape_WrongDimension()
         {
-            var volume = new Double.Volume(new[] { 1.0, 2.0, 3.0 }, new Shape(3));
+            var volume = BuilderInstance.Volume.From(new[] { 1.0, 2.0, 3.0 }, new Shape(3));
             volume.ReShape(1, 4);
         }
 
         [TestMethod]
         public void ReShapeKeep()
         {
-            var volume = new Double.Volume(new[]
+            var volume = BuilderInstance.Volume.From(new[]
             {
                 1.0, 2.0,
                 3.0, 4.0,

--- a/src/ConvNetSharp.Volume.Tests/SingleVolumeTests.cs
+++ b/src/ConvNetSharp.Volume.Tests/SingleVolumeTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using ConvNetSharp.Volume.Single;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ConvNetSharp.Volume.Tests
@@ -9,7 +10,7 @@ namespace ConvNetSharp.Volume.Tests
         protected override Volume<float> NewVolume(double[] values, Shape shape)
         {
             var converted = values.Select(i => (float) i).ToArray();
-            return new Single.Volume(converted, shape);
+            return BuilderInstance.Volume.From(converted, shape);
         }
     }
 }

--- a/src/ConvNetSharp.Volume.Tests/VolumeTests.cs
+++ b/src/ConvNetSharp.Volume.Tests/VolumeTests.cs
@@ -121,7 +121,7 @@ namespace ConvNetSharp.Volume.Tests
             var example = NewVolume(new[] { 1.0 }, new Shape(1));
             var volume = BuilderInstance<T>.Volume.SameAs(example.Storage, Ops<T>.One, new Shape(10));
 
-            // SameAs creates an instance that
+            // From creates an instance that
             // - has the same type of storage as example
             Assert.AreEqual(example.Storage.GetType(), volume.Storage.GetType());
             // - is filled with provided value
@@ -151,7 +151,7 @@ namespace ConvNetSharp.Volume.Tests
             var example = NewVolume(new[] { 1.0 }, new Shape(1));
             var volume = BuilderInstance<T>.Volume.SameAs(example.Storage, new Shape(10));
 
-            // SameAs creates an instance that
+            // From creates an instance that
             // - has the same type of storage as example
             Assert.AreEqual(example.Storage.GetType(), volume.Storage.GetType());
             Assert.AreEqual(10, volume.Shape.GetDimension(0));

--- a/src/ConvNetSharp.Volume/Double/Volume.cs
+++ b/src/ConvNetSharp.Volume/Double/Volume.cs
@@ -4,11 +4,11 @@ namespace ConvNetSharp.Volume.Double
 {
     public class Volume : Volume<double>
     {
-        public Volume(double[] array, Shape shape) : this(new NcwhVolumeStorage<double>(array, shape))
+        internal Volume(double[] array, Shape shape) : this(new NcwhVolumeStorage<double>(array, shape))
         {
         }
 
-        public Volume(VolumeStorage<double> storage) : base(storage)
+        internal Volume(VolumeStorage<double> storage) : base(storage)
         {
         }
 

--- a/src/ConvNetSharp.Volume/Double/VolumeBuilder.cs
+++ b/src/ConvNetSharp.Volume/Double/VolumeBuilder.cs
@@ -24,7 +24,7 @@ namespace ConvNetSharp.Volume.Double
             throw new NotImplementedException();
         }
 
-        public override Volume<double> SameAs(double[] value, Shape shape)
+        public override Volume<double> From(double[] value, Shape shape)
         {
             return new Volume(new NcwhVolumeStorage<double>(value, shape));
         }

--- a/src/ConvNetSharp.Volume/Single/Volume.cs
+++ b/src/ConvNetSharp.Volume/Single/Volume.cs
@@ -4,11 +4,11 @@ namespace ConvNetSharp.Volume.Single
 {
     public class Volume : Volume<float>
     {
-        public Volume(float[] array, Shape shape) : this(new NcwhVolumeStorage<float>(array, shape))
+        internal Volume(float[] array, Shape shape) : this(new NcwhVolumeStorage<float>(array, shape))
         {
         }
 
-        public Volume(VolumeStorage<float> storage) : base(storage)
+        internal Volume(VolumeStorage<float> storage) : base(storage)
         {
         }
 

--- a/src/ConvNetSharp.Volume/Single/VolumeBuilder.cs
+++ b/src/ConvNetSharp.Volume/Single/VolumeBuilder.cs
@@ -24,7 +24,7 @@ namespace ConvNetSharp.Volume.Single
             throw new NotImplementedException();
         }
 
-        public override Volume<float> SameAs(float[] value, Shape shape)
+        public override Volume<float> From(float[] value, Shape shape)
         {
             return new Volume(new NcwhVolumeStorage<float>(value, shape));
         }

--- a/src/ConvNetSharp.Volume/Volume.cs
+++ b/src/ConvNetSharp.Volume/Volume.cs
@@ -58,7 +58,7 @@ namespace ConvNetSharp.Volume
             var data = new T[this.Shape.TotalLength];
             Array.Copy(ToArray(), data, data.Length);
 
-            return BuilderInstance<T>.Volume.SameAs(data, this.Shape);
+            return BuilderInstance<T>.Volume.From(data, this.Shape);
         }
 
         public Volume<T> Convolve(Volume<T> filters, int pad, int stride)
@@ -211,12 +211,12 @@ namespace ConvNetSharp.Volume
 
         public static implicit operator Volume<T>(T t)
         {
-            return BuilderInstance<T>.Volume.SameAs(new[] { t }, new Shape(1));
+            return BuilderInstance<T>.Volume.From(new[] { t }, new Shape(1));
         }
 
         public static implicit operator Volume<T>(T[] t)
         {
-            return BuilderInstance<T>.Volume.SameAs(t, new Shape(1, 1, t.Length, 1));
+            return BuilderInstance<T>.Volume.From(t, new Shape(1, 1, t.Length, 1));
         }
 
         public static implicit operator T(Volume<T> v)

--- a/src/ConvNetSharp.Volume/VolumeBuilder.cs
+++ b/src/ConvNetSharp.Volume/VolumeBuilder.cs
@@ -10,7 +10,7 @@ namespace ConvNetSharp.Volume
     {
         public abstract Volume<T> SameAs(Shape shape);
 
-        public abstract Volume<T> SameAs(T[] value, Shape shape);
+        public abstract Volume<T> From(T[] value, Shape shape);
 
         public abstract Volume<T> Random(Shape shape, double mu = 0, double std = 1.0);
 


### PR DESCRIPTION
* `BuilderInstance<double>.Volume.SameAs` becomes `BuilderInstance<double>.Volume.From` when providing actual data

* Missing init in regression layer + test